### PR TITLE
Add support for union types

### DIFF
--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -219,6 +219,30 @@ class CodeBuilder:
         self.add_line(f"setattr(cls, 'to_dict', to_dict)")
         self.compile()
 
+    def add_pack_union(self, fname, ftype, parent, variant_types, value_name):
+        self._add_type_modules(*variant_types)
+        self.add_line(f'def resolve_union(value):')
+        with self.indent():
+            for variant in variant_types:
+                if is_generic(variant):
+                    variant_name = get_type_origin(variant).__name__
+                else:
+                    variant_name = type_name(variant)
+                self.add_line(f'if isinstance(value, {variant_name}):')
+                with self.indent():
+                    self.add_line('try:')
+                    with self.indent():
+                        packed = self._pack_value(fname, variant, parent, value_name)
+                        self.add_line(f'return {packed}')
+                    self.add_line('except (TypeError, AttributeError, ValueError, LookupError) as e:')
+                    with self.indent():
+                        self.add_line('pass')
+            else:
+                variant_type_names = ", ".join([type_name(v) for v in variant_types])
+                self.add_line(f"raise ValueError('Union value could not be "
+                              f"encoded using types ({variant_type_names})')")
+            return 'resolve_union(value)'
+
     def _pack_value(self, fname, ftype, parent, value_name='value'):
 
         if is_dataclass(ftype):
@@ -240,8 +264,7 @@ class CodeBuilder:
                 if len(args) == 2 and args[1] == NoneType:  # it is Optional
                     return self._pack_value(fname, args[0], parent)
                 else:
-                    raise UnserializableDataError(
-                        'Unions are not supported by mashumaro')
+                    return self.add_pack_union(fname, ftype, parent, args, value_name)
             elif origin_type is typing.AnyStr:
                 raise UnserializableDataError(
                     'AnyStr is not supported by mashumaro')
@@ -340,6 +363,30 @@ class CodeBuilder:
 
         raise UnserializableField(fname, ftype, parent)
 
+    def add_unpack_union(self, fname, ftype, parent, variant_types, value_name):
+        self.add_line(f'def resolve_union(value):')
+        with self.indent():
+            for variant in variant_types:
+                if is_generic(variant):
+                    variant_name = get_type_origin(variant).__name__
+                else:
+                    variant_name = type_name(variant)
+                self.add_line('try:')
+                with self.indent():
+                    packed = self._unpack_field_value(fname, variant, parent, value_name)
+                    self.add_line(f'packed = {packed}')
+                    self.add_line(f'if isinstance(packed, {variant_name}):')
+                    with self.indent():
+                        self.add_line(f'return packed')
+                self.add_line('except (TypeError, AttributeError, ValueError, LookupError) as e:')
+                with self.indent():
+                    self.add_line('pass')
+            else:
+                variant_type_names = ", ".join([type_name(v) for v in variant_types])
+                self.add_line(f"raise ValueError('Union value could not be "
+                              f"decoded using types ({variant_type_names})')")
+            return 'resolve_union(value)'
+
     def _unpack_field_value(self, fname, ftype, parent, value_name='value'):
 
         if is_dataclass(ftype):
@@ -362,8 +409,7 @@ class CodeBuilder:
                 if len(args) == 2 and args[1] == NoneType:  # it is Optional
                     return self._unpack_field_value(fname, args[0], parent)
                 else:
-                    raise UnserializableDataError(
-                        'Unions are not supported by mashumaro')
+                    return self.add_unpack_union(fname, ftype, parent, args, value_name)
             elif origin_type is typing.AnyStr:
                 raise UnserializableDataError(
                     'AnyStr is not supported by mashumaro')

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -1,5 +1,6 @@
 from enum import Enum, IntEnum, Flag, IntFlag
 from dataclasses import dataclass
+from typing import Union, List
 
 from mashumaro import DataClassDictMixin
 from mashumaro.types import SerializableType
@@ -25,11 +26,20 @@ class MyIntFlag(IntFlag):
     b = 2
 
 
+@dataclass 
+class CustomShape(DataClassDictMixin):
+    name: str
+    num_corners: int
+
+@dataclass
+class ShapeCollection(DataClassDictMixin):
+    shapes: List[Union[str, CustomShape]]
+
+
 @dataclass
 class MyDataClass(DataClassDictMixin):
     a: int
-    b: int
-
+    b: Union[int, str]
 
 class MutableString(SerializableType):
     def __init__(self, value: str):

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -58,6 +58,7 @@ class Fixture:
     CHAIN_MAP = collections.ChainMap({'a': 1, 'b': 2}, {'c': 3, 'd': 4})
     MAPS_LIST = [{'a': 1, 'b': 2}, {'c': 3, 'd': 4}]
     DICT = {'a': 1, 'b': 2}
+    MIXED_DICT = {'a': 1, 'b': 'two'}
     BYTES = b'123'
     BYTES_BASE64 = 'MTIz\n'
     BYTE_ARRAY = bytearray(b'123')
@@ -66,7 +67,7 @@ class Fixture:
     INT_ENUM = MyIntEnum.a
     FLAG = MyFlag.a
     INT_FLAG = MyIntFlag.a
-    DATA_CLASS = MyDataClass(a=1, b=2)
+    DATA_CLASS = MyDataClass(a=1, b='two')
     NONE = None
     DATETIME = datetime(2018, 10, 29, 12, 46, 55, 308495)
     DATE = DATETIME.date()
@@ -106,7 +107,7 @@ inner_values = [
     (MyIntEnum, Fixture.INT_ENUM, Fixture.INT_ENUM),
     (MyFlag, Fixture.FLAG, Fixture.FLAG),
     (MyIntFlag, Fixture.INT_FLAG, Fixture.INT_FLAG),
-    (MyDataClass, Fixture.DATA_CLASS, Fixture.DICT),
+    (MyDataClass, Fixture.DATA_CLASS, Fixture.MIXED_DICT),
     (type(None), Fixture.NONE, Fixture.NONE),
     (datetime, Fixture.DATETIME, Fixture.DATETIME),
     (date, Fixture.DATE, Fixture.DATE),
@@ -137,7 +138,7 @@ unsupported_field_types = [
 
 
 T = TypeVar('T', int, str)
-unsupported_typing_primitives = [AnyStr, Union[int, str], T]
+unsupported_typing_primitives = [AnyStr, T]
 
 
 x_factory_mapping = {

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,0 +1,33 @@
+import pytest
+from dataclasses import dataclass
+
+from .entities import (
+    ShapeCollection,
+    CustomShape
+)
+
+from mashumaro.exceptions import UnserializableField, UnserializableDataError,\
+    MissingField, InvalidFieldValue
+
+def test_union():
+    dumped = {'shapes': ['triange', {'name': 'square', 'num_corners' : 4}]}
+    assert ShapeCollection.from_dict(dumped).to_dict() == dumped
+
+def test_invalid_union():
+    dumped = {'shapes': ['triange', {'badfield': True}]}
+    with pytest.raises(InvalidFieldValue):
+        ShapeCollection.from_dict(dumped)
+
+def test_invalid_union_no_match_from_dict():
+    dumped = {'shapes': ['triange', {'name': 'square', 'num_corners': 'four'}]}
+    with pytest.raises(ValueError):
+        ShapeCollection.from_dict(dumped)
+
+def test_invalid_union_no_match_to_dict():
+    invalid = ShapeCollection(shapes=[
+        'triange',
+        CustomShape(name='square', num_corners='four'),
+    ])
+
+    with pytest.raises(ValueError):
+        invalid.to_dict()


### PR DESCRIPTION
This PR adds support for union types in mashumaro.

It works by generating a series of encoders/decoders, one per variant type specified in a Union. This PR includes some example tests, and I have also experimented with using this branch in a reasonably large/mature project that already makes extensive use of Union types too.