### PR TITLE
Non serializable class metadata

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+charset = utf-8
+max_line_length=79
+
+[Makefile]
+indent_style = tab
+
+[*.{yml,yaml,feature,json}]
+indent_size = 2
+
+[*.{tsv,csv}]
+trim_trailing_whitespace = false
+
+[*.rst]
+max_line_length = 80

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ max_line_length=79
 [Makefile]
 indent_style = tab
 
-[*.{yml,yaml,feature,json}]
+[*.{yml,yaml,feature,json,toml}]
 indent_size = 2
 
 [*.{tsv,csv}]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install .
-        pip install pytest-cov coveralls
+        pip install -r requirements-dev.txt
     - name: Run tests with coverage
       run: pytest --cov=.
     - name: Upload Coverage
@@ -48,7 +48,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install .
-        pip install pytest-cov coveralls
+        pip install -r requirements-dev.txt
     - name: Run tests with coverage
       run: pytest --cov=.
     - name: Upload Coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test-posix:
-    name: Tests & coverage [posix]
+    name: Tests on Posix
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -34,7 +34,7 @@ jobs:
         COVERALLS_FLAG_NAME: posix-${{ matrix.python-version }}
         COVERALLS_PARALLEL: true
   test-windows:
-    name: Tests & coverage [windows]
+    name: Tests on Windows
     runs-on: windows-latest
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,30 @@ on:
       - master
 
 jobs:
+  test-code-style:
+    name: Code style tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install .
+          pip install -r requirements-dev.txt
+      - name: Run flake8
+        run: flake8 mashumaro
+      - name: Run black
+        run: black --check .
   test-posix:
     name: Tests on Posix
+    needs:
+      - test-code-style
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,6 +57,8 @@ jobs:
         COVERALLS_PARALLEL: true
   test-windows:
     name: Tests on Windows
+    needs:
+      - test-code-style
     runs-on: windows-latest
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Run tests with coverage
       run: pytest --cov=.
     - name: Upload Coverage
-      run: coveralls
+      run: coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_FLAG_NAME: posix-${{ matrix.python-version }}
@@ -76,7 +76,7 @@ jobs:
     - name: Run tests with coverage
       run: pytest --cov=.
     - name: Upload Coverage
-      run: coveralls
+      run: coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_FLAG_NAME: windows-${{ matrix.python-version }}
@@ -95,6 +95,6 @@ jobs:
     - name: Install dependencies
       run: pip install coveralls
     - name: Finish coveralls
-      run: coveralls --finish
+      run: coveralls --service=github --finish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test-posix:
-    name: Tests & coverage
+    name: Tests & coverage [posix]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -34,7 +34,7 @@ jobs:
         COVERALLS_FLAG_NAME: posix-${{ matrix.python-version }}
         COVERALLS_PARALLEL: true
   test-windows:
-    name: Tests & coverage
+    name: Tests & coverage [windows]
     runs-on: windows-latest
     strategy:
       matrix:
@@ -59,7 +59,9 @@ jobs:
         COVERALLS_PARALLEL: true
   coveralls:
     name: Finish Coveralls
-    needs: test
+    needs:
+    - test-posix
+    - test-windows
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  test:
+  test-posix:
     name: Tests & coverage
     runs-on: ubuntu-latest
     strategy:
@@ -31,7 +31,31 @@ jobs:
       run: coveralls
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
+        COVERALLS_FLAG_NAME: posix-${{ matrix.python-version }}
+        COVERALLS_PARALLEL: true
+  test-windows:
+    name: Tests & coverage
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install .
+        pip install pytest-cov coveralls
+    - name: Run tests with coverage
+      run: pytest --cov=.
+    - name: Upload Coverage
+      run: coveralls
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_FLAG_NAME: windows-${{ matrix.python-version }}
         COVERALLS_PARALLEL: true
   coveralls:
     name: Finish Coveralls

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ please don't hesitate to create an issue or pull request.
 TODO
 --------------------------------------------------------------------------------
 
-* Add hooks
+* add hooks
 * add Union support (try to match types on each call)
 * write benchmarks
 * add optional validation

--- a/README.md
+++ b/README.md
@@ -341,8 +341,11 @@ excessive. You can configure some serialization aspects using
 `field`'s `metadata` attribute:
 
 ```python
-class DataClass(DataClassDictMixin):
+class DataClassA(DataClassDictMixin):
     x: datetime = field(metadata={"deserialize": "ciso8601"})
+
+class DataClassB(DataClassDictMixin):
+    x: datetime = field(metadata={"deserialize": ciso8601.parse_datetime_as_naive})
 ```
 
 Next section describes all supported options.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Table of contents
         * [Serializable Interface](#serializable-interface)
         * [Serialization Strategy](#serialization-strategy)
     * [Using field metadata](#using-field-metadata)
-        * [`deserialize` option](#deserialize-option)
         * [`serialize` option](#serialize-option)
+        * [`deserialize` option](#deserialize-option)
 
 Installation
 --------------------------------------------------------------------------------
@@ -346,6 +346,25 @@ excessive. You can use `dataclasses.field` as a field value and configure some
 serialization aspects through its `metadata` argument. Next section describes
 all supported options to use in `metadata` mapping.
 
+#### `serialize` option
+
+This option allows you to change the default serialization method through
+a value of type `Callable[[Any], Any]` that could be any callable object like
+a function, a class method, a class instance method, an instance of a callable
+class or even a lambda function.
+
+Example:
+
+```python
+@dataclass
+class A(DataClassDictMixin):
+    dt: datetime = field(
+        metadata={
+            "serialize": lambda v: v.strftime('%Y-%m-%d %H:%M:%S')
+        }
+    )
+```
+
 #### `deserialize` option
 
 This option allows you to change the default deserialization method. When using
@@ -390,25 +409,6 @@ class C(DataClassDictMixin):
     dt: List[datetime] = field(
         metadata={
             "deserialize": lambda l: list(map(dateutil.parser.isoparse, l))
-        }
-    )
-```
-
-#### `serialize` option
-
-This option allows you to change the default serialization method through
-a value of type `Callable[[Any], Any]` that could be any callable object like
-a function, a class method, a class instance method, an instance of a callable
-class or even a lambda function.
-
-Example:
-
-```python
-@dataclass
-class A(DataClassDictMixin):
-    dt: datetime = field(
-        metadata={
-            "serialize": lambda v: v.strftime('%Y-%m-%d %H:%M:%S')
         }
     )
 ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Table of contents
         * [Serialization Strategy](#serialization-strategy)
     * [Using field metadata](#using-field-metadata)
         * [`deserialize` option](#deserialize-option)
+        * [`serialize` option](#serialize-option)
 
 Installation
 --------------------------------------------------------------------------------
@@ -341,8 +342,29 @@ assert DateTimeFormats.from_dict(dictionary) == formats
 ### Using field metadata
 
 In some cases creating a new class just for one little thing could be
-excessive. You can configure some serialization aspects using
-`field`'s `metadata` attribute:
+excessive. You can use `dataclasses.field` as a field value and configure some
+serialization aspects through its `metadata` argument. Next section describes
+all supported options to use in `metadata` mapping.
+
+#### `deserialize` option
+
+This option allows you to change the default deserialization method. When using
+this option, the deserialization behaviour depends on what type of value the
+option has. It could be either `Callable[[Any], Any]` or `str`.
+
+A value of type `Callable[[Any], Any]` is a generic way to specify any callable
+object like a function, a class method, a class instance method, an instance
+of a callable class or even a lambda function to be called for deserialization.
+
+A value of type `str` sets a specific engine for deserialization. Keep in mind
+that all possible engines depend on the field type that this option is used
+with. At this moment there are next deserialization engines to choose from:
+
+| Applicable field types     | Supported engines        | Description
+|:-------------------------- |:-------------------------|:------------------------------|
+| `datetime`, `date`, `time` | [`ciso8601`](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601), [`pendulum`](https://github.com/sdispater/pendulum) | How to parse datetime string. By default native [`fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) of corresponding class will be used for `datetime`, `date` and `time` fields. It's the fastest way in most cases, but you can choose an alternative. |
+
+Example:
 
 ```python
 from datetime import datetime
@@ -372,25 +394,24 @@ class C(DataClassDictMixin):
     )
 ```
 
-Next section describes all supported options.
+#### `serialize` option
 
-#### `deserialize` option
+This option allows you to change the default serialization method through
+a value of type `Callable[[Any], Any]` that could be any callable object like
+a function, a class method, a class instance method, an instance of a callable
+class or even a lambda function.
 
-This option allows you to change the default deserialization method. When using
-this option, the deserialization behaviour depends on what type of value the
-option has. It could be either `Callable[[Any], Any]` or `str`.
+Example:
 
-A value of type `Callable[[Any], Any]` is a generic way to specify any callable
-object like a function, a class method, a class instance method, an instance
-of a callable class or even a lambda function to be called for deserialization.
-
-A value of type `str` sets a specific engine for deserialization. Keep in mind
-that all possible engines depend on the field type that this option is used
-with. At this moment there are next deserialization engines to choose from:
-
-| Applicable field types     | Supported engines        | Description
-|:-------------------------- |:-------------------------|:------------------------------|
-| `datetime`, `date`, `time` | [`ciso8601`](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601), [`pendulum`](https://github.com/sdispater/pendulum) | How to parse datetime string. By default native [`fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) of corresponding class will be used for `datetime`, `date` and `time` fields. It's the fastest way in most cases, but you can choose an alternative. |
+```python
+@dataclass
+class A(DataClassDictMixin):
+    dt: datetime = field(
+        metadata={
+            "serialize": lambda v: v.strftime('%Y-%m-%d %H:%M:%S')
+        }
+    )
+```
 
 More options are on the way. If you know which option would be useful for many,
 please don't hesitate to create an issue or pull request.

--- a/README.md
+++ b/README.md
@@ -344,10 +344,22 @@ class DataClass(DataClassDictMixin):
     x: datetime = field(metadata={"deserialize": "ciso8601"})
 ```
 
-At this time there are next options to choose from:
-| Option name      | Value type    | Description                   | Applicable field types     | Possible values        |
-| ---------------- |:-------------:|:------------------------------|:---------------------------|:-----------------------|
-| `deserialize`    | `str`         | How to parse datetime string. By default native [`fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) of corresponding class will be used for `datetime`, `date` and `time` fields. It's the fastest way in most cases, but you can choose an alternative. | `datetime`, `date`, `time` | [`ciso8601`](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601), [`pendulum`](https://github.com/sdispater/pendulum)|
+Next section describes all supported options.
+
+#### `deserialize` option
+
+This option allows you to change the default deserialization method. When using
+this option, the deserialization behaviour depends on what type of value the
+option has. It could be either `Callable[[Any], Any]` or `str`.
+`Callable[[Any], Any]` is a generic way to specify a global function,
+classmethod or a method of a class instance. `str` value sets the engine to use
+for deserialization. Keep in mind that all possible engines depend on the
+field type that this option is used with. At this moment there are next
+deserialization engines to choose from:
+
+| Applicable field types     | Supported engines        | Description
+|:-------------------------- |:-------------------------|:------------------------------|
+| `datetime`, `date`, `time` | [`ciso8601`](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601), [`pendulum`](https://github.com/sdispater/pendulum) | How to parse datetime string. By default native [`fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) of corresponding class will be used for `datetime`, `date` and `time` fields. It's the fastest way in most cases, but you can choose an alternative. |
 
 More options are on the way. If you know which option would be useful for many,
 please don't hesitate to create an issue or pull request.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Table of contents
         * [Serializable Interface](#serializable-interface)
         * [Serialization Strategy](#serialization-strategy)
     * [Using field metadata](#using-field-metadata)
+        * [`deserialize` option](#deserialize-option)
 
 Installation
 --------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -111,7 +111,12 @@ for other less popular built-in types:
 * `uuid.UUID`
 * `decimal.Decimal`
 * `fractions.Fraction`
-* `IPv4Address`, `IPv6Address`, `IPv4Network`, `IPv6Network`, `IPv4Interface` & `IPv6Interface` from `ipaddress`
+* `ipaddress.IPv4Address`
+* `ipaddress.IPv6Address`
+* `ipaddress.IPv4Network`
+* `ipaddress.IPv6Network`
+* `ipaddress.IPv4Interface`
+* `ipaddress.IPv6Interface`
 
 for specific types like *NoneType*, nested dataclasses itself and
 even [user defined classes](#user-defined-classes).

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ deserialization engines to choose from:
 |:-------------------------- |:-------------------------|:------------------------------|
 | `datetime`, `date`, `time` | [`ciso8601`](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601), [`pendulum`](https://github.com/sdispater/pendulum) | How to parse datetime string. By default native [`fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) of corresponding class will be used for `datetime`, `date` and `time` fields. It's the fastest way in most cases, but you can choose an alternative. |
 
-:warning: Using callables as the option value could be problematic in some
+> :warning: Using callables as the option value could be problematic in some
 cases. If you're experiencing difficulties, please create an issue or pull
 request.
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Supported serialization formats
 This framework adds methods for dumping to and loading from the
 following formats:
 
-* plain dict
-* json
-* yaml
-* msgpack
+* [plain dict](https://docs.python.org/3/library/stdtypes.html#mapping-types-dict)
+* [JSON](https://www.json.org)
+* [YAML](https://yaml.org)
+* [MessagePack](https://msgpack.org)
 
 Plain dict can be useful when you need to pass a dict object to a
 third-party library, such as a client for MongoDB.

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ class DataClass(DataClassDictMixin):
 At this time there are next options to choose from:
 | Option name | Value type    | Description                   | Applicable field types     | Possible values        |
 | ----------- |:-------------:|:------------------------------|:---------------------------|:-----------------------|
-| `engine`    | `str`         | How to parse datetime string. By default native [`fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) of corresponding class will be used for `datetime`, `date` and `time` fields. It's the fastest way for most cases, but you can choose an alternative. | `datetime`, `date`, `time` | [`ciso8601`](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601), [`pendulum`](https://github.com/sdispater/pendulum)|
+| `engine`    | `str`         | How to parse datetime string. By default native [`fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) of corresponding class will be used for `datetime`, `date` and `time` fields. It's the fastest way in most cases, but you can choose an alternative. | `datetime`, `date`, `time` | [`ciso8601`](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601), [`pendulum`](https://github.com/sdispater/pendulum)|
 
 More options are on the way.
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ for common built-in types:
 * `bytes`
 * `bytearray`
 
-for built-in datetime oriented types (see [more](#using-field-metadata) details):
+for built-in datetime oriented types (see [more](#deserialize-option) details):
 * `datetime`
 * `date`
 * `time`

--- a/README.md
+++ b/README.md
@@ -483,8 +483,8 @@ class A(DataClassJSONMixin):
         obj.abc = 456
         return obj
 
-print(DataClass.from_dict({"ABC": 123}))    # DataClass(abc=456)
-print(DataClass.from_json('{"ABC": 123}'))  # DataClass(abc=456)
+print(DataClass.from_dict({"abc": 123}))    # DataClass(abc=456)
+print(DataClass.from_json('{"abc": 123}'))  # DataClass(abc=456)
 ```
 
 #### Before serialization

--- a/README.md
+++ b/README.md
@@ -50,47 +50,47 @@ Supported field types
 --------------------------------------------------------------------------------
 
 There is support for generic types from the standard *typing* module:
-* List
-* Tuple
-* Set
-* FrozenSet
-* Deque
-* Dict
-* Mapping
-* MutableMapping
-* ChainMap
-* Sequence
+* `List`
+* `Tuple`
+* `Set`
+* `FrozenSet`
+* `Deque`
+* `Dict`
+* `Mapping`
+* `MutableMapping`
+* `ChainMap`
+* `Sequence`
 
 for special primitives from the *typing* module:
-* Optional
-* Any
+* `Optional`
+* `Any`
 
 for enumerations based on classes from the standard *enum* module:
-* Enum
-* IntEnum
-* Flag
-* IntFlag
+* `Enum`
+* `IntEnum`
+* `Flag`
+* `IntFlag`
 
 for common built-in types:
-* int
-* float
-* bool
-* str
-* bytes
-* bytearray
+* `int`
+* `float`
+* `bool`
+* `str`
+* `bytes`
+* `bytearray`
 
 for built-in datetime oriented types:
-* datetime
-* date
-* time
-* timedelta
-* timezone
+* `datetime`
+* `date`
+* `time`
+* `timedelta`
+* `timezone`
 
 for other less popular built-in types:
-* uuid.UUID
-* decimal.Decimal
-* fractions.Fraction
-* os.PathLike (loads to Path)
+* `uuid.UUID`
+* `decimal.Decimal`
+* `fractions.Fraction`
+* `os.PathLike`
 
 for specific types like *NoneType*, nested dataclasses itself and
 even [user defined classes](#user-defined-classes).

--- a/README.md
+++ b/README.md
@@ -86,11 +86,20 @@ for built-in datetime oriented types:
 * `timedelta`
 * `timezone`
 
+for pathlike types:
+* `PurePath`
+* `Path`
+* `PurePosixPath`
+* `PosixPath`
+* `PureWindowsPath`
+* `WindowsPath`
+* `os.PathLike`
+
+
 for other less popular built-in types:
 * `uuid.UUID`
 * `decimal.Decimal`
 * `fractions.Fraction`
-* `os.PathLike`
 
 for specific types like *NoneType*, nested dataclasses itself and
 even [user defined classes](#user-defined-classes).

--- a/README.md
+++ b/README.md
@@ -424,6 +424,23 @@ class C(DataClassDictMixin):
     )
 ```
 
+If you don't want to remember the names of the options you can use
+`field_params` helper function:
+
+```python
+from dataclasses import dataclass, field
+from mashumaro import DataClassDictMixin, field_options
+
+@dataclass
+class A(DataClassDictMixin):
+    x: int = field(
+        metadata=field_options(
+            serialize=str,
+            deserialize=int
+        )
+    )
+```
+
 More options are on the way. If you know which option would be useful for many,
 please don't hesitate to create an issue or pull request.
 

--- a/README.md
+++ b/README.md
@@ -341,13 +341,13 @@ excessive. You can configure some serialization aspects using
 
 ```python
 class DataClass(DataClassDictMixin):
-    x: datetime = field(metadata={"engine": "ciso8601"})
+    x: datetime = field(metadata={"deserialize": "ciso8601"})
 ```
 
 At this time there are next options to choose from:
-| Option name | Value type    | Description                   | Applicable field types     | Possible values        |
-| ----------- |:-------------:|:------------------------------|:---------------------------|:-----------------------|
-| `engine`    | `str`         | How to parse datetime string. By default native [`fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) of corresponding class will be used for `datetime`, `date` and `time` fields. It's the fastest way in most cases, but you can choose an alternative. | `datetime`, `date`, `time` | [`ciso8601`](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601), [`pendulum`](https://github.com/sdispater/pendulum)|
+| Option name      | Value type    | Description                   | Applicable field types     | Possible values        |
+| ---------------- |:-------------:|:------------------------------|:---------------------------|:-----------------------|
+| `deserialize`    | `str`         | How to parse datetime string. By default native [`fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) of corresponding class will be used for `datetime`, `date` and `time` fields. It's the fastest way in most cases, but you can choose an alternative. | `datetime`, `date`, `time` | [`ciso8601`](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601), [`pendulum`](https://github.com/sdispater/pendulum)|
 
 More options are on the way. If you know which option would be useful for many,
 please don't hesitate to create an issue or pull request.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ Table of contents
 * [Usage example](#usage-example)
 * [How does it work?](#how-does-it-work)
 * [API](#api)
-* [User defined classes](#user-defined-classes)
+* [Customization](#customization)
+    * [User defined classes](#user-defined-classes)
+        * [Serializable Interface](#serializable-interface)
+        * [Serialization Strategy](#serialization-strategy)
+    * [Using field metadata](#using-field-metadata)
 
 Installation
 --------------------------------------------------------------------------------
@@ -79,7 +83,7 @@ for common built-in types:
 * `bytes`
 * `bytearray`
 
-for built-in datetime oriented types:
+for built-in datetime oriented types (see [more](#using-field-metadata) details):
 * `datetime`
 * `date`
 * `time`
@@ -103,7 +107,6 @@ for other less popular built-in types:
 
 for specific types like *NoneType*, nested dataclasses itself and
 even [user defined classes](#user-defined-classes).
-
 
 Usage example
 --------------------------------------------------------------------------------
@@ -237,11 +240,17 @@ dict_params    # dictionary of parameter values passed underhood to `from_dict` 
 decoder_kwargs # keyword arguments for decoder function
 ```
 
-User defined classes
+Customization
 --------------------------------------------------------------------------------
 
+### User defined classes
+
 You can define and use custom classes with *mashumaro*. There are two options
-for customization. The first one is useful when you already have the separate
+for customization.
+
+#### Serializable Interface
+
+The first one is useful when you already have the separate
 custom class and you want to serialize instances of it with *mashumaro*.
 All what you need is to implement *SerializableType* interface:
 
@@ -286,6 +295,8 @@ dictionary = new_year.to_dict()
 assert Holiday.from_dict(dictionary) == new_year
 ```
 
+#### Serialization Strategy
+
 The second option is useful when you want to change the serialization behaviour
 for a class depending on some defined parameters. For this case you can create
 the special class implementing *SerializationStrategy* interface:
@@ -322,11 +333,30 @@ dictionary = formats.to_dict()
 assert DateTimeFormats.from_dict(dictionary) == formats
 ```
 
+### Using field metadata
+
+In some cases creating a new class just for one little thing could be
+excessive. You can configure some serialization aspects using
+`field`'s `metadata` attribute:
+
+```python
+class DataClass(DataClassDictMixin):
+    x: datetime = field(metadata={"engine": "ciso8601"})
+```
+
+At this time there are next options to choose from:
+| Option name | Value type    | Description                   | Applicable field types     | Possible values        |
+| ----------- |:-------------:|:------------------------------|:---------------------------|:-----------------------|
+| `engine`    | `str`         | How to parse datetime string. By default native [`fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) of corresponding class will be used for `datetime`, `date` and `time` fields. It's the fastest way for most cases, but you can choose an alternative. | `datetime`, `date`, `time` | [`ciso8601`](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601), [`pendulum`](https://github.com/sdispater/pendulum)|
+
+More options are on the way.
+
 TODO
 --------------------------------------------------------------------------------
 
+* Add hooks
+* add Union support (try to match types on each call)
 * write benchmarks
 * add optional validation
-* add Union support (try to match types on each call)
 * write custom useful types such as URL, Email etc
 * write documentation

--- a/README.md
+++ b/README.md
@@ -342,18 +342,29 @@ excessive. You can configure some serialization aspects using
 
 ```python
 from datetime import datetime
-from dataclasses import field
+from dataclasses import dataclass, field
+from typing import List
 from mashumaro import DataClassDictMixin
 import ciso8601
+import dateutil
 
-class DataClassA(DataClassDictMixin):
+@dataclass
+class A(DataClassDictMixin):
     x: datetime = field(
-        metadata={"deserialize": "ciso8601"}
+        metadata={"deserialize": "pendulum"}
     )
 
-class DataClassB(DataClassDictMixin):
+class B(DataClassDictMixin):
     x: datetime = field(
         metadata={"deserialize": ciso8601.parse_datetime_as_naive}
+    )
+
+@dataclass
+class C(DataClassDictMixin):
+    dt: List[datetime] = field(
+        metadata={
+            "deserialize": lambda l: list(map(dateutil.parser.isoparse, l))
+        }
     )
 ```
 
@@ -364,14 +375,10 @@ Next section describes all supported options.
 This option allows you to change the default deserialization method. When using
 this option, the deserialization behaviour depends on what type of value the
 option has. It could be either `Callable[[Any], Any]` or `str`.
-A value of type `Callable[[Any], Any]` is a generic way to specify a global
-function, class method or a method of a class instance to be called for
-deserialization. Lambda functions and callable class instances aren't supported
-yet.
 
-> :warning: Using callables as the option value could be problematic in some
-cases. If you're experiencing difficulties, please create an issue or pull
-request.
+A value of type `Callable[[Any], Any]` is a generic way to specify any callable
+object like a function, a class method, a class instance method, an instance
+of a callable class or even a lambda function to be called for deserialization.
 
 A value of type `str` sets a specific engine for deserialization. Keep in mind
 that all possible engines depend on the field type that this option is used

--- a/README.md
+++ b/README.md
@@ -341,6 +341,11 @@ excessive. You can configure some serialization aspects using
 `field`'s `metadata` attribute:
 
 ```python
+from datetime import datetime
+from dataclasses import field
+from mashumaro import DataClassDictMixin
+import ciso8601
+
 class DataClassA(DataClassDictMixin):
     x: datetime = field(
         metadata={"deserialize": "ciso8601"}

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ for other less popular built-in types:
 * `uuid.UUID`
 * `decimal.Decimal`
 * `fractions.Fraction`
+* `IPv4Address`, `IPv6Address`, `IPv4Network`, `IPv6Network`, `IPv4Interface` & `IPv6Interface` from `ipaddress`
 
 for specific types like *NoneType*, nested dataclasses itself and
 even [user defined classes](#user-defined-classes).

--- a/README.md
+++ b/README.md
@@ -364,19 +364,22 @@ Next section describes all supported options.
 This option allows you to change the default deserialization method. When using
 this option, the deserialization behaviour depends on what type of value the
 option has. It could be either `Callable[[Any], Any]` or `str`.
-`Callable[[Any], Any]` is a generic way to specify a global function,
-classmethod or a method of a class instance. `str` value sets the engine to use
-for deserialization. Keep in mind that all possible engines depend on the
-field type that this option is used with. At this moment there are next
-deserialization engines to choose from:
-
-| Applicable field types     | Supported engines        | Description
-|:-------------------------- |:-------------------------|:------------------------------|
-| `datetime`, `date`, `time` | [`ciso8601`](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601), [`pendulum`](https://github.com/sdispater/pendulum) | How to parse datetime string. By default native [`fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) of corresponding class will be used for `datetime`, `date` and `time` fields. It's the fastest way in most cases, but you can choose an alternative. |
+A value of type `Callable[[Any], Any]` is a generic way to specify a global
+function, class method or a method of a class instance to be called for
+deserialization. Lambda functions and callable class instances aren't supported
+yet.
 
 > :warning: Using callables as the option value could be problematic in some
 cases. If you're experiencing difficulties, please create an issue or pull
 request.
+
+A value of type `str` sets a specific engine for deserialization. Keep in mind
+that all possible engines depend on the field type that this option is used
+with. At this moment there are next deserialization engines to choose from:
+
+| Applicable field types     | Supported engines        | Description
+|:-------------------------- |:-------------------------|:------------------------------|
+| `datetime`, `date`, `time` | [`ciso8601`](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601), [`pendulum`](https://github.com/sdispater/pendulum) | How to parse datetime string. By default native [`fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) of corresponding class will be used for `datetime`, `date` and `time` fields. It's the fastest way in most cases, but you can choose an alternative. |
 
 More options are on the way. If you know which option would be useful for many,
 please don't hesitate to create an issue or pull request.

--- a/README.md
+++ b/README.md
@@ -334,6 +334,10 @@ dictionary = formats.to_dict()
 assert DateTimeFormats.from_dict(dictionary) == formats
 ```
 
+> ⚠️ Since PEP-563 [breaks](https://github.com/Fatal1ty/mashumaro/issues/10)
+> `SerializationStrategy`, it will be implemented differently sometime in a
+> future version 2.x.
+
 ### Using field metadata
 
 In some cases creating a new class just for one little thing could be

--- a/README.md
+++ b/README.md
@@ -342,10 +342,14 @@ excessive. You can configure some serialization aspects using
 
 ```python
 class DataClassA(DataClassDictMixin):
-    x: datetime = field(metadata={"deserialize": "ciso8601"})
+    x: datetime = field(
+        metadata={"deserialize": "ciso8601"}
+    )
 
 class DataClassB(DataClassDictMixin):
-    x: datetime = field(metadata={"deserialize": ciso8601.parse_datetime_as_naive})
+    x: datetime = field(
+        metadata={"deserialize": ciso8601.parse_datetime_as_naive}
+    )
 ```
 
 Next section describes all supported options.

--- a/README.md
+++ b/README.md
@@ -361,6 +361,10 @@ deserialization engines to choose from:
 |:-------------------------- |:-------------------------|:------------------------------|
 | `datetime`, `date`, `time` | [`ciso8601`](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601), [`pendulum`](https://github.com/sdispater/pendulum) | How to parse datetime string. By default native [`fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) of corresponding class will be used for `datetime`, `date` and `time` fields. It's the fastest way in most cases, but you can choose an alternative. |
 
+:warning: Using callables as the option value could be problematic in some
+cases. If you're experiencing difficulties, please create an issue or pull
+request.
+
 More options are on the way. If you know which option would be useful for many,
 please don't hesitate to create an issue or pull request.
 

--- a/README.md
+++ b/README.md
@@ -349,7 +349,8 @@ At this time there are next options to choose from:
 | ----------- |:-------------:|:------------------------------|:---------------------------|:-----------------------|
 | `engine`    | `str`         | How to parse datetime string. By default native [`fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) of corresponding class will be used for `datetime`, `date` and `time` fields. It's the fastest way in most cases, but you can choose an alternative. | `datetime`, `date`, `time` | [`ciso8601`](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601), [`pendulum`](https://github.com/sdispater/pendulum)|
 
-More options are on the way.
+More options are on the way. If you know which option would be useful for many,
+please don't hesitate to create an issue or pull request.
 
 TODO
 --------------------------------------------------------------------------------

--- a/examples/json_remapping.py
+++ b/examples/json_remapping.py
@@ -1,15 +1,16 @@
 import json
-from typing import Dict, Union, Any, List
 from dataclasses import dataclass
+from typing import Any, Dict, List, Union
 
 from mashumaro import DataClassJSONMixin
-
 
 Rule = Dict[str, str]
 RemappingRules = Dict[str, Union[str, Rule]]
 
 
-def object_remapper(d: Dict[str, Any], rules: RemappingRules) -> Dict[str, Any]:
+def object_remapper(
+    d: Dict[str, Any], rules: RemappingRules
+) -> Dict[str, Any]:
     result = {}
     for key, value in d.items():
         mapped_key = rules.get(key, key)
@@ -28,8 +29,9 @@ def remapper(data, rules):
         return [object_remapper(d, rules) for d in data]
 
 
-def remap_decoder(data: Union[str, bytes, bytearray],
-                  rules: RemappingRules) -> Dict[Any, Any]:
+def remap_decoder(
+    data: Union[str, bytes, bytearray], rules: RemappingRules
+) -> Dict[Any, Any]:
     d = json.loads(data)
     return remapper(d, rules)
 
@@ -67,16 +69,8 @@ encoded_data = json.dumps(
         "ID": 1,
         "USERNAME": "user",
         "EMAIL": "example@example.org",
-        "COMPANY": {
-            "ID": 1,
-            "NAME": "company1"
-        },
-        "CONTRACTORS": [
-            {
-                "ID": 2,
-                "NAME": "company2"
-            }
-        ]
+        "COMPANY": {"ID": 1, "NAME": "company1"},
+        "CONTRACTORS": [{"ID": 2, "NAME": "company2"}],
     }
 )
 
@@ -85,11 +79,12 @@ user = User(
     username="user",
     email="example@example.org",
     company=Company(id=1, name="company1"),
-    contractors=[Company(id=2, name="company2")]
+    contractors=[Company(id=2, name="company2")],
 )
 
-assert User.from_json(
-    data=encoded_data,
-    decoder=remap_decoder,
-    rules=User.__remapping__
-) == user
+assert (
+    User.from_json(
+        data=encoded_data, decoder=remap_decoder, rules=User.__remapping__
+    )
+    == user
+)

--- a/mashumaro/__init__.py
+++ b/mashumaro/__init__.py
@@ -1,6 +1,13 @@
+from mashumaro.exceptions import MissingField
 from mashumaro.serializer.base.dict import DataClassDictMixin
+from mashumaro.serializer.json import DataClassJSONMixin
 from mashumaro.serializer.msgpack import DataClassMessagePackMixin
 from mashumaro.serializer.yaml import DataClassYAMLMixin
-from mashumaro.serializer.json import DataClassJSONMixin
 
-from mashumaro.exceptions import MissingField
+__all__ = [
+    "MissingField",
+    "DataClassDictMixin",
+    "DataClassJSONMixin",
+    "DataClassMessagePackMixin",
+    "DataClassYAMLMixin",
+]

--- a/mashumaro/__init__.py
+++ b/mashumaro/__init__.py
@@ -1,4 +1,5 @@
 from mashumaro.exceptions import MissingField
+from mashumaro.helper import field_options
 from mashumaro.serializer.base.dict import DataClassDictMixin
 from mashumaro.serializer.json import DataClassJSONMixin
 from mashumaro.serializer.msgpack import DataClassMessagePackMixin
@@ -10,4 +11,5 @@ __all__ = [
     "DataClassJSONMixin",
     "DataClassMessagePackMixin",
     "DataClassYAMLMixin",
+    "field_options",
 ]

--- a/mashumaro/exceptions.py
+++ b/mashumaro/exceptions.py
@@ -16,8 +16,10 @@ class MissingField(LookupError):
         return type_name(self.holder_class)
 
     def __str__(self):
-        return f'Field "{self.field_name}" of type {self.field_type_name}' \
-               f' is missing in {self.holder_class_name} instance'
+        return (
+            f'Field "{self.field_name}" of type {self.field_type_name}'
+            f" is missing in {self.holder_class_name} instance"
+        )
 
 
 class UnserializableDataError(TypeError):
@@ -40,21 +42,18 @@ class UnserializableField(UnserializableDataError):
         return type_name(self.holder_class)
 
     def __str__(self):
-        s = f'Field "{self.field_name}" of type {self.field_type_name} ' \
-               f'in {self.holder_class_name} is not serializable'
+        s = (
+            f'Field "{self.field_name}" of type {self.field_type_name} '
+            f"in {self.holder_class_name} is not serializable"
+        )
         if self.msg:
-            s += f': {self.msg}'
+            s += f": {self.msg}"
         return s
 
 
 class InvalidFieldValue(ValueError):
     def __init__(
-        self,
-        field_name,
-        field_type,
-        field_value,
-        holder_class,
-        msg=None
+        self, field_name, field_type, field_value, holder_class, msg=None
     ):
         self.field_name = field_name
         self.field_type = field_type
@@ -71,9 +70,11 @@ class InvalidFieldValue(ValueError):
         return type_name(self.holder_class)
 
     def __str__(self):
-        s = f'Field "{self.field_name}" of type {self.field_type_name} ' \
-            f'in {self.holder_class_name} has invalid value ' \
-            f'{repr(self.field_value)}'
+        s = (
+            f'Field "{self.field_name}" of type {self.field_type_name} '
+            f"in {self.holder_class_name} has invalid value "
+            f"{repr(self.field_value)}"
+        )
         if self.msg:
-            s += f': {self.msg}'
+            s += f": {self.msg}"
         return s

--- a/mashumaro/exceptions.py
+++ b/mashumaro/exceptions.py
@@ -78,3 +78,7 @@ class InvalidFieldValue(ValueError):
         if self.msg:
             s += f": {self.msg}"
         return s
+
+
+class BadHookSignature(TypeError):
+    pass

--- a/mashumaro/helper.py
+++ b/mashumaro/helper.py
@@ -1,0 +1,11 @@
+from typing import Any, Callable, Optional, Union
+
+
+def field_options(
+    serialize: Optional[Callable[[Any], Any]] = None,
+    deserialize: Optional[Union[str, Callable[[Any], Any]]] = None,
+):
+    return {"serialize": serialize, "deserialize": deserialize}
+
+
+__all__ = ["field_options"]

--- a/mashumaro/meta/helpers.py
+++ b/mashumaro/meta/helpers.py
@@ -29,7 +29,7 @@ def type_name(t):
         return str(t)
     else:
         try:
-            return f"{t.__module__}.{t.__qualname__}"
+            return f"{t.__module__}.{t.__name__}"
         except AttributeError:
             return str(t)
 

--- a/mashumaro/meta/helpers.py
+++ b/mashumaro/meta/helpers.py
@@ -85,6 +85,12 @@ def is_init_var(t):
         raise NotImplementedError
 
 
+def get_class_that_define_method(method_name, cls):
+    for cls in cls.__mro__:
+        if method_name in cls.__dict__:
+            return cls
+
+
 __all__ = [
     "get_imported_module_names",
     "get_type_origin",
@@ -95,4 +101,5 @@ __all__ = [
     "is_type_var",
     "is_class_var",
     "is_init_var",
+    "get_class_that_define_method",
 ]

--- a/mashumaro/meta/helpers.py
+++ b/mashumaro/meta/helpers.py
@@ -85,19 +85,6 @@ def is_init_var(t):
         raise NotImplementedError
 
 
-def is_lambda(t):
-    _lambda = lambda: 0  # noqa
-    return isinstance(t, type(_lambda)) and t.__name__ == _lambda.__name__
-
-
-def is_callable_class_instance(t):
-    return (
-        callable(t)
-        and hasattr(t, "__dict__")
-        and not hasattr(t, "__qualname__")
-    )
-
-
 __all__ = [
     "get_imported_module_names",
     "get_type_origin",
@@ -108,6 +95,4 @@ __all__ = [
     "is_type_var",
     "is_class_var",
     "is_init_var",
-    "is_lambda",
-    "is_callable_class_instance",
 ]

--- a/mashumaro/meta/helpers.py
+++ b/mashumaro/meta/helpers.py
@@ -29,7 +29,7 @@ def type_name(t):
         return str(t)
     else:
         try:
-            return f"{t.__module__}.{t.__name__}"
+            return f"{t.__module__}.{t.__qualname__}"
         except AttributeError:
             return str(t)
 

--- a/mashumaro/meta/helpers.py
+++ b/mashumaro/meta/helpers.py
@@ -85,6 +85,19 @@ def is_init_var(t):
         raise NotImplementedError
 
 
+def is_lambda(t):
+    _lambda = lambda: 0  # noqa
+    return isinstance(t, type(_lambda)) and t.__name__ == _lambda.__name__
+
+
+def is_callable_class_instance(t):
+    return (
+        callable(t)
+        and hasattr(t, "__dict__")
+        and not hasattr(t, "__qualname__")
+    )
+
+
 __all__ = [
     "get_imported_module_names",
     "get_type_origin",
@@ -95,4 +108,6 @@ __all__ = [
     "is_type_var",
     "is_class_var",
     "is_init_var",
+    "is_lambda",
+    "is_callable_class_instance",
 ]

--- a/mashumaro/meta/helpers.py
+++ b/mashumaro/meta/helpers.py
@@ -1,14 +1,17 @@
+import dataclasses
 import types
 import typing
-import dataclasses
 
 from .macros import PY_36, PY_37, PY_38, PY_39
 
 
 def get_imported_module_names():
     # noinspection PyUnresolvedReferences
-    return {value.__name__ for value in globals().values()
-            if isinstance(value, types.ModuleType)}
+    return {
+        value.__name__
+        for value in globals().values()
+        if isinstance(value, types.ModuleType)
+    }
 
 
 def get_type_origin(t):
@@ -59,14 +62,13 @@ def is_union(t):
 
 
 def is_type_var(t):
-    return hasattr(t, '__constraints__')
+    return hasattr(t, "__constraints__")
 
 
 def is_class_var(t):
     if PY_36:
         return (
-            is_special_typing_primitive(t) and
-            type(t).__name__ == '_ClassVar'
+            is_special_typing_primitive(t) and type(t).__name__ == "_ClassVar"
         )
     if PY_37 or PY_38 or PY_39:
         return get_type_origin(t) is typing.ClassVar
@@ -84,13 +86,13 @@ def is_init_var(t):
 
 
 __all__ = [
-    'get_imported_module_names',
-    'get_type_origin',
-    'type_name',
-    'is_special_typing_primitive',
-    'is_generic',
-    'is_union',
-    'is_type_var',
-    'is_class_var',
-    'is_init_var',
+    "get_imported_module_names",
+    "get_type_origin",
+    "type_name",
+    "is_special_typing_primitive",
+    "is_generic",
+    "is_union",
+    "is_type_var",
+    "is_class_var",
+    "is_init_var",
 ]

--- a/mashumaro/meta/macros.py
+++ b/mashumaro/meta/macros.py
@@ -1,10 +1,9 @@
 import sys
 
-
 PY_36 = sys.version_info.major == 3 and sys.version_info.minor == 6
 PY_37 = sys.version_info.major == 3 and sys.version_info.minor == 7
 PY_38 = sys.version_info.major == 3 and sys.version_info.minor == 8
 PY_39 = sys.version_info.major == 3 and sys.version_info.minor == 9
 
 
-__all__ = ['PY_36', 'PY_37', 'PY_38', 'PY_39']
+__all__ = ["PY_36", "PY_37", "PY_38", "PY_39"]

--- a/mashumaro/meta/patch.py
+++ b/mashumaro/meta/patch.py
@@ -6,7 +6,8 @@ def patch_fromisoformat():
         # noinspection PyPackageRequirements
         # noinspection PyUnresolvedReferences
         from backports.datetime_fromisoformat import MonkeyPatch
+
         MonkeyPatch.patch_fromisoformat()
 
 
-__all__ = ['patch_fromisoformat']
+__all__ = ["patch_fromisoformat"]

--- a/mashumaro/serializer/base/__init__.py
+++ b/mashumaro/serializer/base/__init__.py
@@ -1,1 +1,3 @@
 from .dict import DataClassDictMixin
+
+__all__ = ["DataClassDictMixin"]

--- a/mashumaro/serializer/base/dict.py
+++ b/mashumaro/serializer/base/dict.py
@@ -1,10 +1,12 @@
-from typing import Mapping
+from typing import Mapping, Type, TypeVar
 
 from mashumaro.serializer.base.metaprogramming import CodeBuilder
 
+T = TypeVar("T", bound="DataClassDictMixin")
+
 
 class DataClassDictMixin:
-    def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls: Type[T], **kwargs):
         builder = CodeBuilder(cls)
         exc = None
         try:
@@ -19,22 +21,22 @@ class DataClassDictMixin:
             raise exc
 
     def to_dict(
-            self,
-            use_bytes: bool = False,
-            use_enum: bool = False,
-            use_datetime: bool = False) -> dict:
+        self: T,
+        use_bytes: bool = False,
+        use_enum: bool = False,
+        use_datetime: bool = False,
+    ) -> dict:
         pass
 
     @classmethod
     def from_dict(
-            cls,
-            d: Mapping,
-            use_bytes: bool = False,
-            use_enum: bool = False,
-            use_datetime: bool = False) -> 'DataClassDictMixin':
+        cls: Type[T],
+        d: Mapping,
+        use_bytes: bool = False,
+        use_enum: bool = False,
+        use_datetime: bool = False,
+    ) -> T:
         pass
 
 
-__all__ = [
-    'DataClassDictMixin'
-]
+__all__ = ["DataClassDictMixin"]

--- a/mashumaro/serializer/base/dict.py
+++ b/mashumaro/serializer/base/dict.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Type, TypeVar
+from typing import Any, Dict, Mapping, Type, TypeVar
 
 from mashumaro.serializer.base.metaprogramming import CodeBuilder
 
@@ -26,7 +26,7 @@ class DataClassDictMixin:
         use_enum: bool = False,
         use_datetime: bool = False,
     ) -> dict:
-        pass
+        ...
 
     @classmethod
     def from_dict(
@@ -36,7 +36,21 @@ class DataClassDictMixin:
         use_enum: bool = False,
         use_datetime: bool = False,
     ) -> T:
-        pass
+        ...
+
+    @classmethod
+    def __pre_deserialize__(cls: Type[T], d: Dict[Any, Any]) -> Dict[Any, Any]:
+        ...
+
+    @classmethod
+    def __post_deserialize__(cls: Type[T], obj: T) -> T:
+        ...
+
+    def __pre_serialize__(self: T) -> T:
+        ...
+
+    def __post_serialize__(self: T, d: Dict[Any, Any]) -> Dict[Any, Any]:
+        ...
 
 
 __all__ = ["DataClassDictMixin"]

--- a/mashumaro/serializer/base/helpers.py
+++ b/mashumaro/serializer/base/helpers.py
@@ -1,24 +1,26 @@
-import re
 import datetime
+import re
 
 
 def parse_timezone(s: str):
-    regexp = re.compile(r'^UTC(([+-][0-2][0-9]):([0-5][0-9]))?$')
+    regexp = re.compile(r"^UTC(([+-][0-2][0-9]):([0-5][0-9]))?$")
     match = regexp.match(s)
     if not match:
-        raise ValueError(f"Time zone {s} must be either UTC "
-                         f"or in format UTC[+-]hh:mm")
+        raise ValueError(
+            f"Time zone {s} must be either UTC " f"or in format UTC[+-]hh:mm"
+        )
     if match.group(1):
         hours = int(match.group(2))
         minutes = int(match.group(3))
         return datetime.timezone(
             datetime.timedelta(
-                hours=hours,
-                minutes=minutes if hours >= 0 else -minutes))
+                hours=hours, minutes=minutes if hours >= 0 else -minutes
+            )
+        )
     else:
         return datetime.timezone.utc
 
 
 __all__ = [
-    'parse_timezone',
+    "parse_timezone",
 ]

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -4,6 +4,7 @@ import collections
 import collections.abc
 import datetime
 import enum
+import ipaddress
 import os
 import pathlib
 import typing
@@ -487,6 +488,15 @@ class CodeBuilder:
             return overridden or f"{value_name}.tzname(None)"
         elif origin_type is uuid.UUID:
             return overridden or f"str({value_name})"
+        elif origin_type in [
+            ipaddress.IPv4Address,
+            ipaddress.IPv6Address,
+            ipaddress.IPv4Network,
+            ipaddress.IPv6Network,
+            ipaddress.IPv4Interface,
+            ipaddress.IPv6Interface,
+        ]:
+            return overridden or f"str({value_name})"
         elif origin_type is Decimal:
             return overridden or f"str({value_name})"
         elif origin_type is Fraction:
@@ -741,6 +751,18 @@ class CodeBuilder:
             return overridden or f"parse_timezone({value_name})"
         elif origin_type is uuid.UUID:
             return overridden or f"uuid.UUID({value_name})"
+        elif origin_type is ipaddress.IPv4Address:
+            return overridden or f"ipaddress.IPv4Address({value_name})"
+        elif origin_type is ipaddress.IPv6Address:
+            return overridden or f"ipaddress.IPv6Address({value_name})"
+        elif origin_type is ipaddress.IPv4Network:
+            return overridden or f"ipaddress.IPv4Network({value_name})"
+        elif origin_type is ipaddress.IPv6Network:
+            return overridden or f"ipaddress.IPv6Network({value_name})"
+        elif origin_type is ipaddress.IPv4Interface:
+            return overridden or f"ipaddress.IPv4Interface({value_name})"
+        elif origin_type is ipaddress.IPv6Interface:
+            return overridden or f"ipaddress.IPv6Interface({value_name})"
         elif origin_type is Decimal:
             return overridden or f"Decimal({value_name})"
         elif origin_type is Fraction:

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -111,10 +111,7 @@ class CodeBuilder:
         for name in self.__get_field_types(recursive=False):
             field = self.namespace.get(name, MISSING)
             if isinstance(field, Field):
-                if field.metadata is not MISSING:
-                    d[name] = field.metadata
-                else:
-                    d[name] = field.default_factory
+                d[name] = field.metadata
         return d
 
     def _add_type_modules(self, *types_) -> None:

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -386,7 +386,9 @@ class CodeBuilder:
                 raise UnserializableDataError(
                     f"{ftype} as a field type is not supported by mashumaro"
                 )
-        elif issubclass(origin_type, typing.Collection):
+        elif issubclass(origin_type, typing.Collection) and not issubclass(
+            origin_type, enum.Enum
+        ):
             args = getattr(ftype, "__args__", ())
 
             def inner_expr(arg_num=0, v_name="value"):
@@ -567,7 +569,9 @@ class CodeBuilder:
                 raise UnserializableDataError(
                     f"{ftype} as a field type is not supported by mashumaro"
                 )
-        elif issubclass(origin_type, typing.Collection):
+        elif issubclass(origin_type, typing.Collection) and not issubclass(
+            origin_type, enum.Enum
+        ):
             args = getattr(ftype, "__args__", ())
 
             def inner_expr(arg_num=0, v_name="value"):

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -110,7 +110,7 @@ class CodeBuilder:
         d = {}
         for name in self.__get_field_types(recursive=False):
             field = self.namespace.get(name, MISSING)
-            if field is not MISSING:
+            if isinstance(field, Field):
                 if field.metadata is not MISSING:
                     d[name] = field.metadata
                 else:

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -20,11 +20,11 @@ from fractions import Fraction
 
 # noinspection PyUnresolvedReferences
 from mashumaro.exceptions import (  # noqa
+    BadHookSignature,
     InvalidFieldValue,
     MissingField,
     UnserializableDataError,
     UnserializableField,
-    BadHookSignature,
 )
 from mashumaro.meta.helpers import (
     get_imported_module_names,
@@ -177,12 +177,9 @@ class CodeBuilder:
         with self.indent():
             pre_deserialize = self.namespace.get(__PRE_DESERIALIZE__)
             if pre_deserialize:
-                if not isinstance(
-                    pre_deserialize, (classmethod, staticmethod)
-                ):
+                if not isinstance(pre_deserialize, classmethod):
                     raise BadHookSignature(
-                        f"`{__PRE_DESERIALIZE__}` must be a class or static "
-                        f"method with "
+                        f"`{__PRE_DESERIALIZE__}` must be a class method with "
                         f"Callable[[Dict[Any, Any]], Dict[Any, Any]] signature"
                     )
                 else:
@@ -277,12 +274,10 @@ class CodeBuilder:
                     self.add_line("raise")
             post_deserialize = self.namespace.get(__POST_DESERIALIZE__)
             if post_deserialize:
-                if not isinstance(
-                    post_deserialize, (classmethod, staticmethod)
-                ):
+                if not isinstance(post_deserialize, classmethod):
                     raise BadHookSignature(
-                        f"`{__POST_DESERIALIZE__}` must be a class or static "
-                        f"method with Callable[[{type_name(self.cls)}], "
+                        f"`{__POST_DESERIALIZE__}` must be a class method "
+                        f"with Callable[[{type_name(self.cls)}], "
                         f"{type_name(self.cls)}] signature"
                     )
                 else:

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -270,19 +270,37 @@ class CodeBuilder:
         with self.indent():
             self.add_line("kwargs = {}")
             for fname, ftype in self.field_types.items():
+                metadata = self.metadatas.get(fname)
                 self.add_line(f"value = getattr(self, '{fname}')")
                 self.add_line("if value is None:")
                 with self.indent():
                     self.add_line(f"kwargs['{fname}'] = None")
                 self.add_line("else:")
                 with self.indent():
-                    packed_value = self._pack_value(fname, ftype, self.cls)
+                    packed_value = self._pack_value(
+                        fname=fname,
+                        ftype=ftype,
+                        parent=self.cls,
+                        metadata=metadata,
+                    )
                     self.add_line(f"kwargs['{fname}'] = {packed_value}")
             self.add_line("return kwargs")
         self.add_line("setattr(cls, 'to_dict', to_dict)")
         self.compile()
 
-    def _pack_value(self, fname, ftype, parent, value_name="value"):
+    def _pack_value(
+        self, fname, ftype, parent, value_name="value", metadata=None
+    ):
+
+        overridden: typing.Optional[str] = None
+        if metadata is not None:
+            serialize_option = metadata.get("serialize")
+            if callable(serialize_option):
+                setattr(self.cls, f"__{fname}_serialize", serialize_option)
+                self._add_type_modules(self.cls)
+                overridden = (
+                    f"{type_name(parent)}.__{fname}_serialize({value_name})"
+                )
 
         if is_dataclass(ftype):
             return f"{value_name}.to_dict(use_bytes, use_enum, use_datetime)"
@@ -299,7 +317,7 @@ class CodeBuilder:
         origin_type = get_type_origin(ftype)
         if is_special_typing_primitive(origin_type):
             if origin_type is typing.Any:
-                return value_name
+                return overridden or value_name
             elif is_union(ftype):
                 args = getattr(ftype, "__args__", ())
                 if len(args) == 2 and args[1] == NoneType:  # it is Optional
@@ -331,7 +349,10 @@ class CodeBuilder:
                 (typing.List, typing.Deque, typing.Tuple, typing.AbstractSet),
             ):
                 if is_generic(ftype):
-                    return f"[{inner_expr()} for value in {value_name}]"
+                    return (
+                        overridden
+                        or f"[{inner_expr()} for value in {value_name}]"
+                    )
                 elif ftype is list:
                     raise UnserializableField(
                         fname, ftype, parent, "Use typing.List[T] instead"
@@ -368,7 +389,8 @@ class CodeBuilder:
                         )
                     else:
                         return (
-                            f'[{{{inner_expr(0,"key")}:{inner_expr(1)} '
+                            overridden
+                            or f'[{{{inner_expr(0,"key")}:{inner_expr(1)} '
                             f"for key,value in m.items()}} "
                             f"for m in value.maps]"
                         )
@@ -388,43 +410,50 @@ class CodeBuilder:
                         )
                     else:
                         return (
-                            f'{{{inner_expr(0,"key")}: {inner_expr(1)} '
+                            overridden
+                            or f'{{{inner_expr(0,"key")}: {inner_expr(1)} '
                             f"for key, value in {value_name}.items()}}"
                         )
             elif issubclass(origin_type, typing.ByteString):
+                specific = f"encodebytes({value_name}).decode()"
                 return (
-                    f"{value_name} if use_bytes else "
-                    f"encodebytes({value_name}).decode()"
+                    f"{value_name} if use_bytes else {overridden or specific}"
                 )
             elif issubclass(origin_type, str):
-                return value_name
+                return overridden or value_name
             elif issubclass(origin_type, typing.Sequence):
                 if is_generic(ftype):
-                    return f"[{inner_expr()} for value in {value_name}]"
+                    return (
+                        overridden
+                        or f"[{inner_expr()} for value in {value_name}]"
+                    )
         elif issubclass(origin_type, os.PathLike):
-            return f"{value_name}.__fspath__()"
+            return overridden or f"{value_name}.__fspath__()"
         elif issubclass(origin_type, enum.Enum):
-            return f"{value_name} if use_enum else {value_name}.value"
+            specific = f"{value_name}.value"
+            return f"{value_name} if use_enum else {overridden or specific}"
         elif origin_type is int:
-            return f"int({value_name})"
+            return overridden or f"int({value_name})"
         elif origin_type is float:
-            return f"float({value_name})"
+            return overridden or f"float({value_name})"
         elif origin_type in (bool, NoneType):
-            return value_name
+            return overridden or value_name
         elif origin_type in (datetime.datetime, datetime.date, datetime.time):
+            if overridden:
+                return f"{value_name} if use_datetime else {overridden}"
             return (
                 f"{value_name} if use_datetime else {value_name}.isoformat()"
             )
         elif origin_type is datetime.timedelta:
-            return f"{value_name}.total_seconds()"
+            return overridden or f"{value_name}.total_seconds()"
         elif origin_type is datetime.timezone:
-            return f"{value_name}.tzname(None)"
+            return overridden or f"{value_name}.tzname(None)"
         elif origin_type is uuid.UUID:
-            return f"str({value_name})"
+            return overridden or f"str({value_name})"
         elif origin_type is Decimal:
-            return f"str({value_name})"
+            return overridden or f"str({value_name})"
         elif origin_type is Fraction:
-            return f"str({value_name})"
+            return overridden or f"str({value_name})"
 
         raise UnserializableField(fname, ftype, parent)
 

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -455,7 +455,20 @@ class CodeBuilder:
                 if is_generic(ftype):
                     return f'[{inner_expr()} for value in {value_name}]'
         elif issubclass(origin_type, os.PathLike):
-            return f'pathlib.Path({value_name})'
+            if issubclass(origin_type, pathlib.PosixPath):
+                return f'pathlib.PosixPath({value_name})'
+            elif issubclass(origin_type, pathlib.WindowsPath):
+                return f'pathlib.WindowsPath({value_name})'
+            elif issubclass(origin_type, pathlib.Path):
+                return f'pathlib.Path({value_name})'
+            elif issubclass(origin_type, pathlib.PurePosixPath):
+                return f'pathlib.PurePosixPath({value_name})'
+            elif issubclass(origin_type, pathlib.PureWindowsPath):
+                return f'pathlib.PureWindowsPath({value_name})'
+            elif issubclass(origin_type, pathlib.PurePath):
+                return f'pathlib.PurePath({value_name})'
+            else:
+                return f'pathlib.PurePath({value_name})'
         elif issubclass(origin_type, enum.Enum):
             return f'{value_name} if use_enum ' \
                    f'else {type_name(origin_type)}({value_name})'

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -296,11 +296,12 @@ class CodeBuilder:
         if metadata is not None:
             serialize_option = metadata.get("serialize")
             if callable(serialize_option):
-                setattr(self.cls, f"__{fname}_serialize", serialize_option)
-                self._add_type_modules(self.cls)
-                overridden = (
-                    f"{type_name(parent)}.__{fname}_serialize({value_name})"
+                setattr(
+                    self.cls,
+                    f"__{fname}_serialize",
+                    staticmethod(serialize_option),
                 )
+                overridden = f"self.__{fname}_serialize(self.{fname})"
 
         if is_dataclass(ftype):
             return f"{value_name}.to_dict(use_bytes, use_enum, use_datetime)"

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -24,6 +24,7 @@ from mashumaro.exceptions import (  # noqa
     MissingField,
     UnserializableDataError,
     UnserializableField,
+    BadHookSignature,
 )
 from mashumaro.meta.helpers import (
     get_imported_module_names,
@@ -45,6 +46,12 @@ patch_fromisoformat()
 
 NoneType = type(None)
 INITIAL_MODULES = get_imported_module_names()
+
+
+__PRE_SERIALIZE__ = "__pre_serialize__"
+__PRE_DESERIALIZE__ = "__pre_deserialize__"
+__POST_SERIALIZE__ = "__post_serialize__"
+__POST_DESERIALIZE__ = "__post_deserialize__"
 
 
 class CodeBuilder:
@@ -168,6 +175,18 @@ class CodeBuilder:
             "use_datetime=False):"
         )
         with self.indent():
+            pre_deserialize = self.namespace.get(__PRE_DESERIALIZE__)
+            if pre_deserialize:
+                if not isinstance(
+                    pre_deserialize, (classmethod, staticmethod)
+                ):
+                    raise BadHookSignature(
+                        f"`{__PRE_DESERIALIZE__}` must be a class or static "
+                        f"method with "
+                        f"Callable[[Dict[Any, Any]], Dict[Any, Any]] signature"
+                    )
+                else:
+                    self.add_line(f"d = cls.{__PRE_DESERIALIZE__}(d)")
             self.add_line("try:")
             with self.indent():
                 self.add_line("kwargs = {}")
@@ -256,7 +275,22 @@ class CodeBuilder:
                 self.add_line("else:")
                 with self.indent():
                     self.add_line("raise")
-            self.add_line("return cls(**kwargs)")
+            post_deserialize = self.namespace.get(__POST_DESERIALIZE__)
+            if post_deserialize:
+                if not isinstance(
+                    post_deserialize, (classmethod, staticmethod)
+                ):
+                    raise BadHookSignature(
+                        f"`{__POST_DESERIALIZE__}` must be a class or static "
+                        f"method with Callable[[{type_name(self.cls)}], "
+                        f"{type_name(self.cls)}] signature"
+                    )
+                else:
+                    self.add_line(
+                        f"return cls.{__POST_DESERIALIZE__}(cls(**kwargs))"
+                    )
+            else:
+                self.add_line("return cls(**kwargs)")
         self.add_line("setattr(cls, 'from_dict', from_dict)")
         self.compile()
 
@@ -268,6 +302,9 @@ class CodeBuilder:
             "use_datetime=False):"
         )
         with self.indent():
+            pre_serialize = self.namespace.get(__PRE_SERIALIZE__)
+            if pre_serialize:
+                self.add_line(f"self = self.{__PRE_SERIALIZE__}()")
             self.add_line("kwargs = {}")
             for fname, ftype in self.field_types.items():
                 metadata = self.metadatas.get(fname)
@@ -284,7 +321,11 @@ class CodeBuilder:
                         metadata=metadata,
                     )
                     self.add_line(f"kwargs['{fname}'] = {packed_value}")
-            self.add_line("return kwargs")
+            post_serialize = self.namespace.get(__POST_SERIALIZE__)
+            if post_serialize:
+                self.add_line(f"return self.{__POST_SERIALIZE__}(kwargs)")
+            else:
+                self.add_line("return kwargs")
         self.add_line("setattr(cls, 'to_dict', to_dict)")
         self.compile()
 

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -467,8 +467,10 @@ class CodeBuilder:
                 return f'pathlib.PureWindowsPath({value_name})'
             elif issubclass(origin_type, pathlib.PurePath):
                 return f'pathlib.PurePath({value_name})'
-            else:
+            elif origin_type is os.PathLike:
                 return f'pathlib.PurePath({value_name})'
+            else:
+                return f'{type_name(origin_type)}({value_name})'
         elif issubclass(origin_type, enum.Enum):
             return f'{value_name} if use_enum ' \
                    f'else {type_name(origin_type)}({value_name})'

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -348,7 +348,7 @@ class CodeBuilder:
                     f"__{fname}_serialize",
                     staticmethod(serialize_option),
                 )
-                overridden = f"self.__{fname}_serialize(self.{fname})"
+                return f"self.__{fname}_serialize(self.{fname})"
 
         if is_dataclass(ftype):
             return f"{value_name}.to_dict(use_bytes, use_enum, use_datetime)"
@@ -369,7 +369,7 @@ class CodeBuilder:
             elif is_union(ftype):
                 args = getattr(ftype, "__args__", ())
                 if len(args) == 2 and args[1] == NoneType:  # it is Optional
-                    return self._pack_value(fname, args[0], parent)
+                    return self._pack_value(fname, args[0], parent, metadata=metadata)
                 else:
                     raise UnserializableDataError(
                         "Unions are not supported by mashumaro"
@@ -392,7 +392,7 @@ class CodeBuilder:
             args = getattr(ftype, "__args__", ())
 
             def inner_expr(arg_num=0, v_name="value"):
-                return self._pack_value(fname, args[arg_num], parent, v_name)
+                return self._pack_value(fname, args[arg_num], parent, v_name, metadata=metadata)
 
             if issubclass(
                 origin_type,
@@ -526,7 +526,7 @@ class CodeBuilder:
             deserialize_option = metadata.get("deserialize")
             if callable(deserialize_option):
                 setattr(self.cls, f"__{fname}_deserialize", deserialize_option)
-                overridden = f"cls.__{fname}_deserialize({value_name})"
+                return f"cls.__{fname}_deserialize({value_name})"
 
         if is_dataclass(ftype):
             return (

--- a/mashumaro/serializer/json.py
+++ b/mashumaro/serializer/json.py
@@ -1,42 +1,53 @@
 import json
-from typing import Union, Optional, Callable, Dict, Mapping, TypeVar, Type
 from types import MappingProxyType
+from typing import Any, Dict, Mapping, Type, TypeVar, Union
+
+from typing_extensions import Protocol
 
 from mashumaro.serializer.base import DataClassDictMixin
 
-
 DEFAULT_DICT_PARAMS = {
-    'use_bytes': False,
-    'use_enum': False,
-    'use_datetime': False
+    "use_bytes": False,
+    "use_enum": False,
+    "use_datetime": False,
 }
 EncodedData = Union[str, bytes, bytearray]
-Encoder = Callable[[Dict], EncodedData]
-Decoder = Callable[[EncodedData], Dict]
-T = TypeVar('T', bound='DataClassJSONMixin')
+T = TypeVar("T", bound="DataClassJSONMixin")
+
+
+class Encoder(Protocol):
+    def __call__(self, obj, **kwargs) -> EncodedData:
+        pass
+
+
+class Decoder(Protocol):
+    def __call__(self, s: EncodedData, **kwargs) -> Dict[Any, Any]:
+        pass
 
 
 class DataClassJSONMixin(DataClassDictMixin):
     def to_json(
-            self: T,
-            encoder: Optional[Encoder] = json.dumps,
-            dict_params: Optional[Mapping] = MappingProxyType({}),
-            **encoder_kwargs) -> EncodedData:
+        self: T,
+        encoder: Encoder = json.dumps,
+        dict_params: Mapping = MappingProxyType({}),
+        **encoder_kwargs,
+    ) -> EncodedData:
 
         return encoder(
             self.to_dict(**dict(DEFAULT_DICT_PARAMS, **dict_params)),
-            **encoder_kwargs
+            **encoder_kwargs,
         )
 
     @classmethod
     def from_json(
-            cls: Type[T],
-            data: EncodedData,
-            decoder: Optional[Decoder] = json.loads,
-            dict_params: Optional[Mapping] = MappingProxyType({}),
-            **decoder_kwargs) -> T:
+        cls: Type[T],
+        data: EncodedData,
+        decoder: Decoder = json.loads,
+        dict_params: Mapping = MappingProxyType({}),
+        **decoder_kwargs,
+    ) -> T:
 
         return cls.from_dict(
             decoder(data, **decoder_kwargs),
-            **dict(DEFAULT_DICT_PARAMS, **dict_params)
+            **dict(DEFAULT_DICT_PARAMS, **dict_params),
         )

--- a/mashumaro/serializer/json.py
+++ b/mashumaro/serializer/json.py
@@ -6,7 +6,6 @@ from typing_extensions import Protocol
 
 from mashumaro.serializer.base import DataClassDictMixin
 
-
 DEFAULT_DICT_PARAMS = {
     "use_bytes": False,
     "use_enum": False,
@@ -16,12 +15,14 @@ EncodedData = Union[str, bytes, bytearray]
 T = TypeVar("T", bound="DataClassJSONMixin")
 
 
-class Encoder(Protocol):
-    def __call__(self, obj, **kwargs) -> EncodedData: ...
+class Encoder(Protocol):  # pragma no cover
+    def __call__(self, obj, **kwargs) -> EncodedData:
+        ...
 
 
-class Decoder(Protocol):
-    def __call__(self, s: EncodedData, **kwargs) -> Dict[Any, Any]: ...
+class Decoder(Protocol):  # pragma no cover
+    def __call__(self, s: EncodedData, **kwargs) -> Dict[Any, Any]:
+        ...
 
 
 class DataClassJSONMixin(DataClassDictMixin):

--- a/mashumaro/serializer/json.py
+++ b/mashumaro/serializer/json.py
@@ -6,6 +6,7 @@ from typing_extensions import Protocol
 
 from mashumaro.serializer.base import DataClassDictMixin
 
+
 DEFAULT_DICT_PARAMS = {
     "use_bytes": False,
     "use_enum": False,
@@ -16,13 +17,11 @@ T = TypeVar("T", bound="DataClassJSONMixin")
 
 
 class Encoder(Protocol):
-    def __call__(self, obj, **kwargs) -> EncodedData:
-        pass
+    def __call__(self, obj, **kwargs) -> EncodedData: ...
 
 
 class Decoder(Protocol):
-    def __call__(self, s: EncodedData, **kwargs) -> Dict[Any, Any]:
-        pass
+    def __call__(self, s: EncodedData, **kwargs) -> Dict[Any, Any]: ...
 
 
 class DataClassJSONMixin(DataClassDictMixin):

--- a/mashumaro/serializer/msgpack.py
+++ b/mashumaro/serializer/msgpack.py
@@ -7,7 +7,6 @@ from typing_extensions import Protocol
 
 from mashumaro.serializer.base import DataClassDictMixin
 
-
 DEFAULT_DICT_PARAMS = {
     "use_bytes": True,
     "use_enum": False,
@@ -17,12 +16,14 @@ EncodedData = Union[str, bytes, bytearray]
 T = TypeVar("T", bound="DataClassMessagePackMixin")
 
 
-class Encoder(Protocol):
-    def __call__(self, o, **kwargs) -> EncodedData: ...
+class Encoder(Protocol):  # pragma no cover
+    def __call__(self, o, **kwargs) -> EncodedData:
+        ...
 
 
-class Decoder(Protocol):
-    def __call__(self, packed: EncodedData, **kwargs) -> Dict[Any, Any]: ...
+class Decoder(Protocol):  # pragma no cover
+    def __call__(self, packed: EncodedData, **kwargs) -> Dict[Any, Any]:
+        ...
 
 
 class DataClassMessagePackMixin(DataClassDictMixin):

--- a/mashumaro/serializer/msgpack.py
+++ b/mashumaro/serializer/msgpack.py
@@ -7,6 +7,7 @@ from typing_extensions import Protocol
 
 from mashumaro.serializer.base import DataClassDictMixin
 
+
 DEFAULT_DICT_PARAMS = {
     "use_bytes": True,
     "use_enum": False,
@@ -17,13 +18,11 @@ T = TypeVar("T", bound="DataClassMessagePackMixin")
 
 
 class Encoder(Protocol):
-    def __call__(self, o, **kwargs) -> EncodedData:
-        pass
+    def __call__(self, o, **kwargs) -> EncodedData: ...
 
 
 class Decoder(Protocol):
-    def __call__(self, packed: EncodedData, **kwargs) -> Dict[Any, Any]:
-        pass
+    def __call__(self, packed: EncodedData, **kwargs) -> Dict[Any, Any]: ...
 
 
 class DataClassMessagePackMixin(DataClassDictMixin):

--- a/mashumaro/serializer/yaml.py
+++ b/mashumaro/serializer/yaml.py
@@ -1,42 +1,43 @@
-from typing import Union, Optional, Callable, Dict, Mapping, TypeVar, Type
 from types import MappingProxyType
+from typing import Callable, Dict, Mapping, Optional, Type, TypeVar, Union
 
 import yaml
 
 from mashumaro.serializer.base import DataClassDictMixin
 
-
 DEFAULT_DICT_PARAMS = {
-    'use_bytes': False,
-    'use_enum': False,
-    'use_datetime': False
+    "use_bytes": False,
+    "use_enum": False,
+    "use_datetime": False,
 }
 EncodedData = Union[str, bytes]
 Encoder = Callable[[Dict], EncodedData]
 Decoder = Callable[[EncodedData], Dict]
-T = TypeVar('T', bound='DataClassYAMLMixin')
+T = TypeVar("T", bound="DataClassYAMLMixin")
 
 
 class DataClassYAMLMixin(DataClassDictMixin):
     def to_yaml(
-            self: T,
-            encoder: Optional[Encoder] = yaml.dump,
-            dict_params: Optional[Mapping] = MappingProxyType({}),
-            **encoder_kwargs) -> EncodedData:
+        self: T,
+        encoder: Encoder = yaml.dump,
+        dict_params: Mapping = MappingProxyType({}),
+        **encoder_kwargs,
+    ) -> EncodedData:
 
         return encoder(
             self.to_dict(**dict(DEFAULT_DICT_PARAMS, **dict_params)),
-            **encoder_kwargs
+            **encoder_kwargs,
         )
 
     @classmethod
     def from_yaml(
-            cls: Type[T],
-            data: EncodedData,
-            decoder: Optional[Decoder] = yaml.safe_load,
-            dict_params: Optional[Mapping] = MappingProxyType({}),
-            **decoder_kwargs) -> T:
+        cls: Type[T],
+        data: EncodedData,
+        decoder: Decoder = yaml.safe_load,
+        dict_params: Mapping = MappingProxyType({}),
+        **decoder_kwargs,
+    ) -> T:
         return cls.from_dict(
             decoder(data, **decoder_kwargs),
-            **dict(DEFAULT_DICT_PARAMS, **dict_params)
+            **dict(DEFAULT_DICT_PARAMS, **dict_params),
         )

--- a/mashumaro/serializer/yaml.py
+++ b/mashumaro/serializer/yaml.py
@@ -5,6 +5,7 @@ import yaml
 
 from mashumaro.serializer.base import DataClassDictMixin
 
+
 DEFAULT_DICT_PARAMS = {
     "use_bytes": False,
     "use_enum": False,

--- a/mashumaro/serializer/yaml.py
+++ b/mashumaro/serializer/yaml.py
@@ -1,10 +1,9 @@
 from types import MappingProxyType
-from typing import Callable, Dict, Mapping, Optional, Type, TypeVar, Union
+from typing import Callable, Dict, Mapping, Type, TypeVar, Union
 
 import yaml
 
 from mashumaro.serializer.base import DataClassDictMixin
-
 
 DEFAULT_DICT_PARAMS = {
     "use_bytes": False,

--- a/mashumaro/types.py
+++ b/mashumaro/types.py
@@ -40,7 +40,7 @@ class RoundedDecimal(SerializationStrategy):
 
 
 __all__ = [
-    'SerializableType',
-    'SerializationStrategy',
-    'RoundedDecimal',
+    "SerializableType",
+    "SerializationStrategy",
+    "RoundedDecimal",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[mypy]
+ignore_missing_imports = true
+
+[flake8]
+max-line-length = 79
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+ensure_newline_before_comments = true
+
+[tool.black]
+line-length = 79
+target-version = ['py36', 'py37', 'py38']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ mypy>=0.790
 flake8>=3.8.4
 isort>=5.6.4
 pytest>=6.2.1
+pytest-mock>=3.5.1
 pytest-cov>=2.10.1
 coveralls>=2.2.0
 flake8-isort>=4.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,12 @@
+mypy>=0.790
+flake8>=3.8.4
+isort>=5.6.4
+pytest>=6.2.1
+pytest-cov>=2.10.1
+coveralls>=2.2.0
+flake8-isort>=4.0.0
+black>=20.8b1
+
+# third party features
+ciso8601>=2.1.3
+pendulum>=2.1.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ isort>=5.6.4
 pytest>=6.2.1
 pytest-mock>=3.5.1
 pytest-cov>=2.10.1
-coveralls>=2.2.0
+coveralls>=3.0.0
 flake8-isort>=4.0.0
 black>=20.8b1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 setup(
     name="mashumaro",
     version="1.17",
     description="Fast serialization framework on top of dataclasses",
-    long_description=open('README.md', encoding='utf8').read(),
-    long_description_content_type='text/markdown',
+    long_description=open("README.md", encoding="utf8").read(),
+    long_description_content_type="text/markdown",
     platforms="all",
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
@@ -23,13 +22,14 @@ setup(
     license="Apache License, Version 2.0",
     author="Alexander Tikhonov",
     author_email="random.gauss@gmail.com",
-    url='https://github.com/Fatal1ty/mashumaro',
+    url="https://github.com/Fatal1ty/mashumaro",
     packages=find_packages(exclude=("tests",)),
     python_requires=">=3.6",
     install_requires=[
         "dataclasses;python_version=='3.6'",
         "msgpack>=0.5.6",
         "pyyaml>=3.13",
-        "backports-datetime-fromisoformat;python_version=='3.6'"
-    ]
+        "backports-datetime-fromisoformat;python_version=='3.6'",
+        "typing_extensions",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="mashumaro",
-    version="1.20",
+    version="1.21",
     description="Fast serialization framework on top of dataclasses",
     long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="mashumaro",
-    version="1.17",
+    version="1.18",
     description="Fast serialization framework on top of dataclasses",
     long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="mashumaro",
-    version="1.19",
+    version="1.20",
     description="Fast serialization framework on top of dataclasses",
     long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="mashumaro",
-    version="1.21",
+    version="1.22",
     description="Fast serialization framework on top of dataclasses",
     long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="mashumaro",
-    version="1.22",
+    version="1.23",
     description="Fast serialization framework on top of dataclasses",
     long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="mashumaro",
-    version="1.18",
+    version="1.19",
     description="Fast serialization framework on top of dataclasses",
     long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="mashumaro",
-    version="1.16",
+    version="1.17",
     description="Fast serialization framework on top of dataclasses",
     long_description=open('README.md', encoding='utf8').read(),
     long_description_content_type='text/markdown',

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -61,4 +61,4 @@ class CustomPath(PathLike):
         return self._path
 
     def __eq__(self, other):
-        return str(self) == str(other)
+        return str(self).replace('\\', '/') == str(other).replace('\\', '/')

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -61,4 +61,4 @@ class CustomPath(PathLike):
         return self._path
 
     def __eq__(self, other):
-        return str(self).replace('\\', '/') == str(other).replace('\\', '/')
+        return isinstance(other, CustomPath) and self._path == other._path

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -57,8 +57,5 @@ class CustomPath(PathLike):
     def __fspath__(self):
         return self._path
 
-    def __str__(self):
-        return self._path
-
     def __eq__(self, other):
         return isinstance(other, CustomPath) and self._path == other._path

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -11,6 +11,11 @@ class MyEnum(Enum):
     b = "letter b"
 
 
+class MyStrEnum(str, Enum):
+    a = "letter a"
+    b = "letter b"
+
+
 class MyIntEnum(IntEnum):
     a = 1
     b = 2

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -1,14 +1,14 @@
-from os import PathLike
-from enum import Enum, IntEnum, Flag, IntFlag
 from dataclasses import dataclass
+from enum import Enum, Flag, IntEnum, IntFlag
+from os import PathLike
 
 from mashumaro import DataClassDictMixin
 from mashumaro.types import SerializableType
 
 
 class MyEnum(Enum):
-    a = 'letter a'
-    b = 'letter b'
+    a = "letter a"
+    b = "letter b"
 
 
 class MyIntEnum(IntEnum):
@@ -40,11 +40,11 @@ class MutableString(SerializableType):
         return str(self)
 
     @classmethod
-    def _deserialize(cls, value: str) -> 'MutableString':
+    def _deserialize(cls, value: str) -> "MutableString":
         return MutableString(value)
 
     def __str__(self):
-        return ''.join(self.characters)
+        return "".join(self.characters)
 
     def __eq__(self, other):
         return self.characters == other.characters
@@ -52,7 +52,7 @@ class MutableString(SerializableType):
 
 class CustomPath(PathLike):
     def __init__(self, *args: str):
-        self._path = '/'.join(args)
+        self._path = "/".join(args)
 
     def __fspath__(self):
         return self._path

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -1,3 +1,4 @@
+from os import PathLike
 from enum import Enum, IntEnum, Flag, IntFlag
 from dataclasses import dataclass
 
@@ -47,3 +48,17 @@ class MutableString(SerializableType):
 
     def __eq__(self, other):
         return self.characters == other.characters
+
+
+class CustomPath(PathLike):
+    def __init__(self, *args: str):
+        self._path = '/'.join(args)
+
+    def __fspath__(self):
+        return self._path
+
+    def __str__(self):
+        return self._path
+
+    def __eq__(self, other):
+        return str(self) == str(other)

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -90,24 +90,12 @@ class Fixture:
     FRACTION_STR = '1/3'
     MUTABLE_STRING = MutableString(STR)
     MUTABLE_STRING_STR = STR
-    POSIX_PATH = PosixPath('/a/b/c')
-    POSIX_PATH_STR = '/a/b/c'
-    WINDOWS_PATH = PureWindowsPath('C:/Windows')
-    WINDOWS_PATH_STR = 'C:\\Windows'
     PATH = Path('/a/b/c')
     PATH_STR = '/a/b/c'
-    PURE_POSIX_PATH = PurePosixPath('/a/b/c')
-    PURE_POSIX_PATH_STR = '/a/b/c'
-    PURE_WINDOWS_PATH = PureWindowsPath('C:/Program Files')
-    PURE_WINDOWS_PATH_STR = 'C:\\Program Files'
     PURE_PATH = PurePath('/a/b/c')
     PURE_PATH_STR = '/a/b/c'
     CUSTOM_PATH = CustomPath('/a/b/c')
     CUSTOM_PATH_STR = '/a/b/c'
-
-
-if os.name != 'posix':
-    Fixture.PURE_WINDOWS_PATH = WindowsPath('C:/Program Files')
 
 
 inner_values = [
@@ -142,17 +130,20 @@ inner_values = [
     (decimal.Decimal, Fixture.DECIMAL, Fixture.DECIMAL_STR),
     (fractions.Fraction, Fixture.FRACTION, Fixture.FRACTION_STR),
     (MutableString, Fixture.MUTABLE_STRING, Fixture.MUTABLE_STRING_STR),
-    (PosixPath, Fixture.POSIX_PATH, Fixture.POSIX_PATH_STR),
     (Path, Fixture.PATH, Fixture.PATH_STR),
-    (PurePosixPath, Fixture.PURE_POSIX_PATH, Fixture.PURE_POSIX_PATH_STR),
-    (PureWindowsPath, Fixture.PURE_WINDOWS_PATH, Fixture.PURE_WINDOWS_PATH_STR),
     (PurePath, Fixture.PURE_PATH, Fixture.PURE_PATH_STR),
 ]
 
-if os.name != 'posix':
-    inner_values.append(
-        (WindowsPath, Fixture.WINDOWS_PATH, Fixture.WINDOWS_PATH_STR)
-    )
+if os.name == 'posix':
+    inner_values.extend([
+        (PosixPath, PosixPath('/a/b/c'), '/a/b/c'),
+        (PurePosixPath, PurePosixPath('/a/b/c'), '/a/b/c'),
+    ])
+else:
+    inner_values.extend([
+        (WindowsPath, WindowsPath('C:/Windows'), 'C:\\Windows'),
+        (PureWindowsPath, PureWindowsPath('C:/Program Files'), 'C:\\Program Files'),
+    ])
 
 
 hashable_inner_values = [

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -729,6 +729,15 @@ def test_dataclass_with_field_and_default():
     assert DataClass().to_dict() == {"x": 1}
 
 
+def test_dataclass_with_field_and_no_default():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: int = field(metadata={})
+
+    with pytest.raises(MissingField):
+        assert DataClass.from_dict({})
+
+
 def test_dataclass_with_field_and_default_factory():
     @dataclass
     class DataClass(DataClassDictMixin):

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1,8 +1,8 @@
 import collections
 import decimal
 import fractions
-import os
 import ipaddress
+import os
 import uuid
 from dataclasses import InitVar, dataclass, field
 from datetime import date, datetime, time, timedelta, timezone

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -49,6 +49,7 @@ from .entities import (
     MyIntFlag,
     MyDataClass,
     MutableString,
+    CustomPath,
 )
 
 import pytest
@@ -101,6 +102,8 @@ class Fixture:
     PURE_WINDOWS_PATH_STR = 'C:\\Program Files'
     PURE_PATH = PurePath('/a/b/c')
     PURE_PATH_STR = '/a/b/c'
+    CUSTOM_PATH = CustomPath('/a/b/c')
+    CUSTOM_PATH_STR = '/a/b/c'
 
 
 if os.name != 'posix':
@@ -814,3 +817,14 @@ def test_invalid_field_value_deserialization_with_rounded_decimal_with_default()
 
     with pytest.raises(InvalidFieldValue):
         DataClass.from_dict({'x': 'bad_value'})
+
+
+def test_custom_pathlike_type():
+
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: CustomPath
+
+    instance = DataClass(x=Fixture.CUSTOM_PATH)
+    assert instance.to_dict() == {'x': Fixture.CUSTOM_PATH_STR}
+    assert DataClass.from_dict({'x': Fixture.CUSTOM_PATH_STR}) == instance

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -90,8 +90,6 @@ class Fixture:
     FRACTION_STR = '1/3'
     MUTABLE_STRING = MutableString(STR)
     MUTABLE_STRING_STR = STR
-    PURE_PATH = PurePath('/a/b/c')
-    PURE_PATH_STR = '/a/b/c'
     CUSTOM_PATH = CustomPath('/a/b/c')
     CUSTOM_PATH_STR = '/a/b/c'
 
@@ -128,18 +126,19 @@ inner_values = [
     (decimal.Decimal, Fixture.DECIMAL, Fixture.DECIMAL_STR),
     (fractions.Fraction, Fixture.FRACTION, Fixture.FRACTION_STR),
     (MutableString, Fixture.MUTABLE_STRING, Fixture.MUTABLE_STRING_STR),
-    (PurePath, Fixture.PURE_PATH, Fixture.PURE_PATH_STR),
 ]
 
 if os.name == 'posix':
     inner_values.extend([
         (Path, Path('/a/b/c'), '/a/b/c'),
+        (PurePath, PurePath('/a/b/c'), '/a/b/c'),
         (PosixPath, PosixPath('/a/b/c'), '/a/b/c'),
         (PurePosixPath, PurePosixPath('/a/b/c'), '/a/b/c'),
     ])
 else:
     inner_values.extend([
         (Path, Path('/a/b/c'), '\\a\\b\\c'),
+        (PurePath, PurePath('/a/b/c'), '\\a\\b\\c'),
         (WindowsPath, WindowsPath('C:/Windows'), 'C:\\Windows'),
         (PureWindowsPath, PureWindowsPath('C:/Program Files'), 'C:\\Program Files'),
     ])

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -126,6 +126,7 @@ inner_values = [
     (decimal.Decimal, Fixture.DECIMAL, Fixture.DECIMAL_STR),
     (fractions.Fraction, Fixture.FRACTION, Fixture.FRACTION_STR),
     (MutableString, Fixture.MUTABLE_STRING, Fixture.MUTABLE_STRING_STR),
+    (CustomPath, Fixture.CUSTOM_PATH, Fixture.CUSTOM_PATH_STR),
 ]
 
 if os.name == 'posix':
@@ -806,14 +807,3 @@ def test_invalid_field_value_deserialization_with_rounded_decimal_with_default()
 
     with pytest.raises(InvalidFieldValue):
         DataClass.from_dict({'x': 'bad_value'})
-
-
-def test_custom_pathlike_type():
-
-    @dataclass
-    class DataClass(DataClassDictMixin):
-        x: CustomPath
-
-    instance = DataClass(x=Fixture.CUSTOM_PATH)
-    assert instance.to_dict() == {'x': Fixture.CUSTOM_PATH_STR}
-    assert DataClass.from_dict({'x': Fixture.CUSTOM_PATH_STR}) == instance

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 import decimal
 import fractions
@@ -6,7 +7,14 @@ from enum import Enum
 from datetime import datetime, date, time, timedelta, timezone
 from dataclasses import dataclass, InitVar, field
 from queue import Queue
-from pathlib import Path
+from pathlib import (
+    Path,
+    PosixPath,
+    WindowsPath,
+    PurePosixPath,
+    PureWindowsPath,
+    PurePath,
+)
 from typing import (
     Hashable,
     List,
@@ -81,8 +89,22 @@ class Fixture:
     FRACTION_STR = '1/3'
     MUTABLE_STRING = MutableString(STR)
     MUTABLE_STRING_STR = STR
-    PATH = Path('.')
-    PATH_STR = '.'
+    POSIX_PATH = PosixPath('/a/b/c')
+    POSIX_PATH_STR = '/a/b/c'
+    WINDOWS_PATH = PureWindowsPath('C:/Windows')
+    WINDOWS_PATH_STR = 'C:\\Windows'
+    PATH = Path('/a/b/c')
+    PATH_STR = '/a/b/c'
+    PURE_POSIX_PATH = PurePosixPath('/a/b/c')
+    PURE_POSIX_PATH_STR = '/a/b/c'
+    PURE_WINDOWS_PATH = PureWindowsPath('C:/Program Files')
+    PURE_WINDOWS_PATH_STR = 'C:\\Program Files'
+    PURE_PATH = PurePath('/a/b/c')
+    PURE_PATH_STR = '/a/b/c'
+
+
+if os.name != 'posix':
+    Fixture.PURE_WINDOWS_PATH = WindowsPath('C:/Program Files')
 
 
 inner_values = [
@@ -117,8 +139,17 @@ inner_values = [
     (decimal.Decimal, Fixture.DECIMAL, Fixture.DECIMAL_STR),
     (fractions.Fraction, Fixture.FRACTION, Fixture.FRACTION_STR),
     (MutableString, Fixture.MUTABLE_STRING, Fixture.MUTABLE_STRING_STR),
-    (Path, Fixture.PATH, Fixture.PATH_STR)
+    (PosixPath, Fixture.POSIX_PATH, Fixture.POSIX_PATH_STR),
+    (Path, Fixture.PATH, Fixture.PATH_STR),
+    (PurePosixPath, Fixture.PURE_POSIX_PATH, Fixture.PURE_POSIX_PATH_STR),
+    (PureWindowsPath, Fixture.PURE_WINDOWS_PATH, Fixture.PURE_WINDOWS_PATH_STR),
+    (PurePath, Fixture.PURE_PATH, Fixture.PURE_PATH_STR),
 ]
+
+if os.name != 'posix':
+    inner_values.append(
+        (WindowsPath, Fixture.WINDOWS_PATH, Fixture.WINDOWS_PATH_STR)
+    )
 
 
 hashable_inner_values = [

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -62,7 +62,6 @@ from .entities import (
 )
 from .utils import same_types
 
-
 NoneType = type(None)
 
 

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -90,8 +90,6 @@ class Fixture:
     FRACTION_STR = '1/3'
     MUTABLE_STRING = MutableString(STR)
     MUTABLE_STRING_STR = STR
-    PATH = Path('/a/b/c')
-    PATH_STR = '/a/b/c'
     PURE_PATH = PurePath('/a/b/c')
     PURE_PATH_STR = '/a/b/c'
     CUSTOM_PATH = CustomPath('/a/b/c')
@@ -130,17 +128,18 @@ inner_values = [
     (decimal.Decimal, Fixture.DECIMAL, Fixture.DECIMAL_STR),
     (fractions.Fraction, Fixture.FRACTION, Fixture.FRACTION_STR),
     (MutableString, Fixture.MUTABLE_STRING, Fixture.MUTABLE_STRING_STR),
-    (Path, Fixture.PATH, Fixture.PATH_STR),
     (PurePath, Fixture.PURE_PATH, Fixture.PURE_PATH_STR),
 ]
 
 if os.name == 'posix':
     inner_values.extend([
+        (Path, Path('/a/b/c'), '/a/b/c'),
         (PosixPath, PosixPath('/a/b/c'), '/a/b/c'),
         (PurePosixPath, PurePosixPath('/a/b/c'), '/a/b/c'),
     ])
 else:
     inner_values.extend([
+        (Path, Path('/a/b/c'), '\\a\\b\\c'),
         (WindowsPath, WindowsPath('C:/Windows'), 'C:\\Windows'),
         (PureWindowsPath, PureWindowsPath('C:/Program Files'), 'C:\\Program Files'),
     ])

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -135,6 +135,7 @@ if os.name == 'posix':
         (PurePath, PurePath('/a/b/c'), '/a/b/c'),
         (PosixPath, PosixPath('/a/b/c'), '/a/b/c'),
         (PurePosixPath, PurePosixPath('/a/b/c'), '/a/b/c'),
+        (os.PathLike, PurePosixPath('/a/b/c'), '/a/b/c'),
     ])
 else:
     inner_values.extend([
@@ -142,6 +143,7 @@ else:
         (PurePath, PurePath('/a/b/c'), '\\a\\b\\c'),
         (WindowsPath, WindowsPath('C:/Windows'), 'C:\\Windows'),
         (PureWindowsPath, PureWindowsPath('C:/Program Files'), 'C:\\Program Files'),
+        (os.PathLike, PureWindowsPath('/a/b/c'), '\\a\\b\\c'),
     ])
 
 

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -2,6 +2,7 @@ import collections
 import decimal
 import fractions
 import os
+import ipaddress
 import uuid
 from dataclasses import InitVar, dataclass, field
 from datetime import date, datetime, time, timedelta, timezone
@@ -94,6 +95,18 @@ class Fixture:
     TIMEZONE = timezone(timedelta(hours=3))
     UUID = uuid.UUID("3c25dd74-f208-46a2-9606-dd3919e975b7")
     UUID_STR = "3c25dd74-f208-46a2-9606-dd3919e975b7"
+    IP4ADDRESS_STR = "127.0.0.1"
+    IP4ADDRESS = ipaddress.IPv4Address(IP4ADDRESS_STR)
+    IP6ADDRESS_STR = "::1"
+    IP6ADDRESS = ipaddress.IPv6Address(IP6ADDRESS_STR)
+    IP4NETWORK_STR = "127.0.0.0/8"
+    IP4NETWORK = ipaddress.IPv4Network(IP4NETWORK_STR)
+    IP6NETWORK_STR = "::/128"
+    IP6NETWORK = ipaddress.IPv6Network(IP6NETWORK_STR)
+    IP4INTERFACE_STR = "192.168.1.1/24"
+    IP4INTERFACE = ipaddress.IPv4Interface(IP4INTERFACE_STR)
+    IP6INTERFACE_STR = "::1/128"
+    IP6INTERFACE = ipaddress.IPv6Interface(IP6INTERFACE_STR)
     DECIMAL = decimal.Decimal("1.33")
     DECIMAL_STR = "1.33"
     FRACTION = fractions.Fraction("1/3")
@@ -134,6 +147,12 @@ inner_values = [
     (timedelta, Fixture.TIMEDELTA, Fixture.TIMEDELTA.total_seconds()),
     (timezone, Fixture.TIMEZONE, "UTC+03:00"),
     (uuid.UUID, Fixture.UUID, Fixture.UUID_STR),
+    (ipaddress.IPv4Address, Fixture.IP4ADDRESS, Fixture.IP4ADDRESS_STR),
+    (ipaddress.IPv6Address, Fixture.IP6ADDRESS, Fixture.IP6ADDRESS_STR),
+    (ipaddress.IPv4Network, Fixture.IP4NETWORK, Fixture.IP4NETWORK_STR),
+    (ipaddress.IPv6Network, Fixture.IP6NETWORK, Fixture.IP6NETWORK_STR),
+    (ipaddress.IPv4Interface, Fixture.IP4INTERFACE, Fixture.IP4INTERFACE_STR),
+    (ipaddress.IPv6Interface, Fixture.IP6INTERFACE, Fixture.IP6INTERFACE_STR),
     (decimal.Decimal, Fixture.DECIMAL, Fixture.DECIMAL_STR),
     (fractions.Fraction, Fixture.FRACTION, Fixture.FRACTION_STR),
     (MutableString, Fixture.MUTABLE_STRING, Fixture.MUTABLE_STRING_STR),

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -60,6 +60,7 @@ from .entities import (
     MyFlag,
     MyIntEnum,
     MyIntFlag,
+    MyStrEnum,
 )
 from .utils import same_types
 
@@ -84,6 +85,7 @@ class Fixture:
     STR = "123"
     ENUM = MyEnum.a
     INT_ENUM = MyIntEnum.a
+    STR_ENUM = MyStrEnum.a
     FLAG = MyFlag.a
     INT_FLAG = MyIntFlag.a
     DATA_CLASS = MyDataClass(a=1, b=2)
@@ -136,6 +138,7 @@ inner_values = [
     (bytearray, Fixture.BYTE_ARRAY, Fixture.BYTE_ARRAY),
     (str, Fixture.STR, Fixture.STR),
     (MyEnum, Fixture.ENUM, Fixture.ENUM),
+    (MyStrEnum, Fixture.STR_ENUM, Fixture.STR_ENUM),
     (MyIntEnum, Fixture.INT_ENUM, Fixture.INT_ENUM),
     (MyFlag, Fixture.FLAG, Fixture.FLAG),
     (MyIntFlag, Fixture.INT_FLAG, Fixture.INT_FLAG),

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1,58 +1,66 @@
-import os
-import uuid
+import collections
 import decimal
 import fractions
-import collections
+import os
+import uuid
+from dataclasses import InitVar, dataclass, field
+from datetime import date, datetime, time, timedelta, timezone
 from enum import Enum
-from datetime import datetime, date, time, timedelta, timezone
-from dataclasses import dataclass, InitVar, field
-from queue import Queue
 from pathlib import (
     Path,
     PosixPath,
-    WindowsPath,
+    PurePath,
     PurePosixPath,
     PureWindowsPath,
-    PurePath,
+    WindowsPath,
 )
+from queue import Queue
 from typing import (
-    Hashable,
-    List,
-    Deque,
-    Tuple,
-    Set,
-    FrozenSet,
-    MutableSet,
-    ChainMap,
-    Dict,
-    Mapping,
-    MutableMapping,
-    Sequence,
-    Optional,
     Any,
     AnyStr,
-    Union,
-    TypeVar,
+    ChainMap,
     ClassVar,
-)
-
-from mashumaro import DataClassDictMixin
-from mashumaro.exceptions import UnserializableField, UnserializableDataError,\
-    MissingField, InvalidFieldValue
-from mashumaro.types import RoundedDecimal, SerializableType,\
-    SerializationStrategy
-from .utils import same_types
-from .entities import (
-    MyEnum,
-    MyIntEnum,
-    MyFlag,
-    MyIntFlag,
-    MyDataClass,
-    MutableString,
-    CustomPath,
+    Deque,
+    Dict,
+    FrozenSet,
+    Hashable,
+    List,
+    Mapping,
+    MutableMapping,
+    MutableSet,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
 )
 
 import pytest
+
+from mashumaro import DataClassDictMixin
+from mashumaro.exceptions import (
+    InvalidFieldValue,
+    MissingField,
+    UnserializableDataError,
+    UnserializableField,
+)
+from mashumaro.types import (
+    RoundedDecimal,
+    SerializableType,
+    SerializationStrategy,
+)
+
+from .entities import (
+    CustomPath,
+    MutableString,
+    MyDataClass,
+    MyEnum,
+    MyFlag,
+    MyIntEnum,
+    MyIntFlag,
+)
+from .utils import same_types
 
 
 class Fixture:
@@ -64,13 +72,13 @@ class Fixture:
     DEQUE = collections.deque([1, 2, 3])
     SET = {1, 2, 3}
     FROZEN_SET = frozenset([1, 2, 3])
-    CHAIN_MAP = collections.ChainMap({'a': 1, 'b': 2}, {'c': 3, 'd': 4})
-    MAPS_LIST = [{'a': 1, 'b': 2}, {'c': 3, 'd': 4}]
-    DICT = {'a': 1, 'b': 2}
-    BYTES = b'123'
-    BYTES_BASE64 = 'MTIz\n'
-    BYTE_ARRAY = bytearray(b'123')
-    STR = '123'
+    CHAIN_MAP = collections.ChainMap({"a": 1, "b": 2}, {"c": 3, "d": 4})
+    MAPS_LIST = [{"a": 1, "b": 2}, {"c": 3, "d": 4}]
+    DICT = {"a": 1, "b": 2}
+    BYTES = b"123"
+    BYTES_BASE64 = "MTIz\n"
+    BYTE_ARRAY = bytearray(b"123")
+    STR = "123"
     ENUM = MyEnum.a
     INT_ENUM = MyIntEnum.a
     FLAG = MyFlag.a
@@ -82,16 +90,16 @@ class Fixture:
     TIME = DATETIME.time()
     TIMEDELTA = timedelta(3.14159265358979323846)
     TIMEZONE = timezone(timedelta(hours=3))
-    UUID = uuid.UUID('3c25dd74-f208-46a2-9606-dd3919e975b7')
-    UUID_STR = '3c25dd74-f208-46a2-9606-dd3919e975b7'
-    DECIMAL = decimal.Decimal('1.33')
-    DECIMAL_STR = '1.33'
-    FRACTION = fractions.Fraction('1/3')
-    FRACTION_STR = '1/3'
+    UUID = uuid.UUID("3c25dd74-f208-46a2-9606-dd3919e975b7")
+    UUID_STR = "3c25dd74-f208-46a2-9606-dd3919e975b7"
+    DECIMAL = decimal.Decimal("1.33")
+    DECIMAL_STR = "1.33"
+    FRACTION = fractions.Fraction("1/3")
+    FRACTION_STR = "1/3"
     MUTABLE_STRING = MutableString(STR)
     MUTABLE_STRING_STR = STR
-    CUSTOM_PATH = CustomPath('/a/b/c')
-    CUSTOM_PATH_STR = '/a/b/c'
+    CUSTOM_PATH = CustomPath("/a/b/c")
+    CUSTOM_PATH_STR = "/a/b/c"
 
 
 inner_values = [
@@ -121,7 +129,7 @@ inner_values = [
     (date, Fixture.DATE, Fixture.DATE),
     (time, Fixture.TIME, Fixture.TIME),
     (timedelta, Fixture.TIMEDELTA, Fixture.TIMEDELTA.total_seconds()),
-    (timezone, Fixture.TIMEZONE, 'UTC+03:00'),
+    (timezone, Fixture.TIMEZONE, "UTC+03:00"),
     (uuid.UUID, Fixture.UUID, Fixture.UUID_STR),
     (decimal.Decimal, Fixture.DECIMAL, Fixture.DECIMAL_STR),
     (fractions.Fraction, Fixture.FRACTION, Fixture.FRACTION_STR),
@@ -129,26 +137,35 @@ inner_values = [
     (CustomPath, Fixture.CUSTOM_PATH, Fixture.CUSTOM_PATH_STR),
 ]
 
-if os.name == 'posix':
-    inner_values.extend([
-        (Path, Path('/a/b/c'), '/a/b/c'),
-        (PurePath, PurePath('/a/b/c'), '/a/b/c'),
-        (PosixPath, PosixPath('/a/b/c'), '/a/b/c'),
-        (PurePosixPath, PurePosixPath('/a/b/c'), '/a/b/c'),
-        (os.PathLike, PurePosixPath('/a/b/c'), '/a/b/c'),
-    ])
+if os.name == "posix":
+    inner_values.extend(
+        [
+            (Path, Path("/a/b/c"), "/a/b/c"),
+            (PurePath, PurePath("/a/b/c"), "/a/b/c"),
+            (PosixPath, PosixPath("/a/b/c"), "/a/b/c"),
+            (PurePosixPath, PurePosixPath("/a/b/c"), "/a/b/c"),
+            (os.PathLike, PurePosixPath("/a/b/c"), "/a/b/c"),
+        ]
+    )
 else:
-    inner_values.extend([
-        (Path, Path('/a/b/c'), '\\a\\b\\c'),
-        (PurePath, PurePath('/a/b/c'), '\\a\\b\\c'),
-        (WindowsPath, WindowsPath('C:/Windows'), 'C:\\Windows'),
-        (PureWindowsPath, PureWindowsPath('C:/Program Files'), 'C:\\Program Files'),
-        (os.PathLike, PureWindowsPath('/a/b/c'), '\\a\\b\\c'),
-    ])
+    inner_values.extend(
+        [
+            (Path, Path("/a/b/c"), "\\a\\b\\c"),
+            (PurePath, PurePath("/a/b/c"), "\\a\\b\\c"),
+            (WindowsPath, WindowsPath("C:/Windows"), "C:\\Windows"),
+            (
+                PureWindowsPath,
+                PureWindowsPath("C:/Program Files"),
+                "C:\\Program Files",
+            ),
+            (os.PathLike, PureWindowsPath("/a/b/c"), "\\a\\b\\c"),
+        ]
+    )
 
 
 hashable_inner_values = [
-    (type_, value, value_dumped) for type_, value, value_dumped in inner_values
+    (type_, value, value_dumped)
+    for type_, value, value_dumped in inner_values
     if isinstance(value, Hashable) and isinstance(value_dumped, Hashable)
 ]
 
@@ -158,11 +175,18 @@ generic_mapping_types = [Dict, Mapping, MutableMapping]
 
 
 unsupported_field_types = [
-    list, collections.deque, tuple, set, frozenset,
-    collections.ChainMap, dict, Queue]
+    list,
+    collections.deque,
+    tuple,
+    set,
+    frozenset,
+    collections.ChainMap,
+    dict,
+    Queue,
+]
 
 
-T = TypeVar('T', int, str)
+T = TypeVar("T", int, str)
 unsupported_typing_primitives = [AnyStr, Union[int, str], T]
 
 
@@ -176,12 +200,14 @@ x_factory_mapping = {
     Dict: lambda items: {k: v for k, v in items},
     Mapping: lambda items: {k: v for k, v in items},
     MutableMapping: lambda items: {k: v for k, v in items},
-    ChainMap: lambda items: collections.ChainMap(*({k: v} for k, v in items))
+    ChainMap: lambda items: collections.ChainMap(*({k: v} for k, v in items)),
 }
 
 
 # noinspection PyCallingNonCallable
-def check_one_arg_generic(type_, value_info, use_bytes, use_enum, use_datetime):
+def check_one_arg_generic(
+    type_, value_info, use_bytes, use_enum, use_datetime
+):
     x_type, x_value, x_value_dumped = value_info
 
     @dataclass
@@ -198,42 +224,40 @@ def check_one_arg_generic(type_, value_info, use_bytes, use_enum, use_datetime):
     elif isinstance(x_value_dumped, Enum):
         v_dumped = x_value_dumped if use_enum else x_value_dumped.value
     elif isinstance(x_value_dumped, (datetime, date, time)):
-        v_dumped = x_value_dumped if use_datetime \
-            else x_value_dumped.isoformat()
+        v_dumped = (
+            x_value_dumped if use_datetime else x_value_dumped.isoformat()
+        )
     else:
         v_dumped = x_value_dumped
-    dumped = {'x': list(x_factory([v_dumped for _ in range(3)]))}
+    dumped = {"x": list(x_factory([v_dumped for _ in range(3)]))}
     instance_dumped = instance.to_dict(
-        use_bytes=use_bytes,
-        use_enum=use_enum,
-        use_datetime=use_datetime
+        use_bytes=use_bytes, use_enum=use_enum, use_datetime=use_datetime
     )
     instance_loaded = DataClass.from_dict(
         dumped,
         use_bytes=use_bytes,
         use_enum=use_enum,
-        use_datetime=use_datetime
+        use_datetime=use_datetime,
     )
     assert instance_dumped == dumped
     assert instance_loaded == instance
     instance_dumped = instance.to_dict(
-        use_bytes=use_bytes,
-        use_enum=use_enum,
-        use_datetime=use_datetime
+        use_bytes=use_bytes, use_enum=use_enum, use_datetime=use_datetime
     )
     instance_loaded = DataClass.from_dict(
         dumped,
         use_bytes=use_bytes,
         use_enum=use_enum,
-        use_datetime=use_datetime
+        use_datetime=use_datetime,
     )
     assert same_types(instance_dumped, dumped)
     assert same_types(instance_loaded.x, x)
 
 
 # noinspection PyCallingNonCallable
-def check_two_args_generic(type_, key_info, value_info, use_bytes, use_enum,
-                           use_datetime):
+def check_two_args_generic(
+    type_, key_info, value_info, use_bytes, use_enum, use_datetime
+):
     k_type, k_value, k_value_dumped = key_info
     v_type, v_value, v_value_dumped = value_info
 
@@ -252,8 +276,9 @@ def check_two_args_generic(type_, key_info, value_info, use_bytes, use_enum,
     elif isinstance(k_value_dumped, Enum):
         k_dumped = k_value_dumped if use_enum else k_value_dumped.value
     elif isinstance(k_value_dumped, (datetime, date, time)):
-        k_dumped = k_value_dumped if use_datetime \
-            else k_value_dumped.isoformat()
+        k_dumped = (
+            k_value_dumped if use_datetime else k_value_dumped.isoformat()
+        )
     else:
         k_dumped = k_value_dumped
     if v_value_dumped is Fixture.BYTES:
@@ -263,46 +288,45 @@ def check_two_args_generic(type_, key_info, value_info, use_bytes, use_enum,
     elif isinstance(v_value_dumped, Enum):
         v_dumped = v_value_dumped if use_enum else v_value_dumped.value
     elif isinstance(v_value_dumped, (datetime, date, time)):
-        v_dumped = v_value_dumped if use_datetime \
-            else v_value_dumped.isoformat()
+        v_dumped = (
+            v_value_dumped if use_datetime else v_value_dumped.isoformat()
+        )
     else:
         v_dumped = v_value_dumped
     if type_ is ChainMap:
-        dumped = {'x': x_factory([(k_dumped, v_dumped) for _ in range(3)]).maps}
+        dumped = {
+            "x": x_factory([(k_dumped, v_dumped) for _ in range(3)]).maps
+        }
     else:
-        dumped = {'x': x_factory([(k_dumped, v_dumped) for _ in range(3)])}
+        dumped = {"x": x_factory([(k_dumped, v_dumped) for _ in range(3)])}
     instance_dumped = instance.to_dict(
-        use_bytes=use_bytes,
-        use_enum=use_enum,
-        use_datetime=use_datetime
+        use_bytes=use_bytes, use_enum=use_enum, use_datetime=use_datetime
     )
     instance_loaded = DataClass.from_dict(
         dumped,
         use_bytes=use_bytes,
         use_enum=use_enum,
-        use_datetime=use_datetime
+        use_datetime=use_datetime,
     )
     assert instance_dumped == dumped
     assert instance_loaded == instance
     instance_dumped = instance.to_dict(
-        use_bytes=use_bytes,
-        use_enum=use_enum,
-        use_datetime=use_datetime
+        use_bytes=use_bytes, use_enum=use_enum, use_datetime=use_datetime
     )
     instance_loaded = DataClass.from_dict(
         dumped,
         use_bytes=use_bytes,
         use_enum=use_enum,
-        use_datetime=use_datetime
+        use_datetime=use_datetime,
     )
     assert same_types(instance_dumped, dumped)
     assert same_types(instance_loaded.x, x)
 
 
-@pytest.mark.parametrize('use_datetime', [True, False])
-@pytest.mark.parametrize('use_enum', [True, False])
-@pytest.mark.parametrize('use_bytes', [True, False])
-@pytest.mark.parametrize('value_info', inner_values)
+@pytest.mark.parametrize("use_datetime", [True, False])
+@pytest.mark.parametrize("use_enum", [True, False])
+@pytest.mark.parametrize("use_bytes", [True, False])
+@pytest.mark.parametrize("value_info", inner_values)
 def test_one_level(value_info, use_bytes, use_enum, use_datetime):
     x_type, x_value, x_value_dumped = value_info
 
@@ -318,176 +342,190 @@ def test_one_level(value_info, use_bytes, use_enum, use_datetime):
     elif isinstance(x_value_dumped, Enum):
         v_dumped = x_value_dumped if use_enum else x_value_dumped.value
     elif isinstance(x_value_dumped, (datetime, date, time)):
-        v_dumped = x_value_dumped if use_datetime \
-            else x_value_dumped.isoformat()
+        v_dumped = (
+            x_value_dumped if use_datetime else x_value_dumped.isoformat()
+        )
     else:
         v_dumped = x_value_dumped
-    dumped = {'x': v_dumped}
+    dumped = {"x": v_dumped}
     instance_dumped = instance.to_dict(
-        use_bytes=use_bytes,
-        use_enum=use_enum,
-        use_datetime=use_datetime
+        use_bytes=use_bytes, use_enum=use_enum, use_datetime=use_datetime
     )
     instance_loaded = DataClass.from_dict(
         dumped,
         use_bytes=use_bytes,
         use_enum=use_enum,
-        use_datetime=use_datetime
+        use_datetime=use_datetime,
     )
     assert instance_dumped == dumped
     assert instance_loaded == instance
     instance_dumped = instance.to_dict(
-        use_bytes=use_bytes,
-        use_enum=use_enum,
-        use_datetime=use_datetime
+        use_bytes=use_bytes, use_enum=use_enum, use_datetime=use_datetime
     )
     instance_loaded = DataClass.from_dict(
         dumped,
         use_bytes=use_bytes,
         use_enum=use_enum,
-        use_datetime=use_datetime
+        use_datetime=use_datetime,
     )
     assert same_types(instance_dumped, dumped)
     assert same_types(instance_loaded.x, x_value)
 
 
-@pytest.mark.parametrize('use_datetime', [True, False])
-@pytest.mark.parametrize('use_enum', [True, False])
-@pytest.mark.parametrize('use_bytes', [True, False])
-@pytest.mark.parametrize('value_info', inner_values)
+@pytest.mark.parametrize("use_datetime", [True, False])
+@pytest.mark.parametrize("use_enum", [True, False])
+@pytest.mark.parametrize("use_bytes", [True, False])
+@pytest.mark.parametrize("value_info", inner_values)
 def test_with_generic_list(value_info, use_bytes, use_enum, use_datetime):
     check_one_arg_generic(List, value_info, use_bytes, use_enum, use_datetime)
 
 
-@pytest.mark.parametrize('use_datetime', [True, False])
-@pytest.mark.parametrize('use_enum', [True, False])
-@pytest.mark.parametrize('use_bytes', [True, False])
-@pytest.mark.parametrize('value_info', inner_values)
+@pytest.mark.parametrize("use_datetime", [True, False])
+@pytest.mark.parametrize("use_enum", [True, False])
+@pytest.mark.parametrize("use_bytes", [True, False])
+@pytest.mark.parametrize("value_info", inner_values)
 def test_with_generic_deque(value_info, use_bytes, use_enum, use_datetime):
     check_one_arg_generic(Deque, value_info, use_bytes, use_enum, use_datetime)
 
 
-@pytest.mark.parametrize('use_datetime', [True, False])
-@pytest.mark.parametrize('use_enum', [True, False])
-@pytest.mark.parametrize('use_bytes', [True, False])
-@pytest.mark.parametrize('value_info', inner_values)
+@pytest.mark.parametrize("use_datetime", [True, False])
+@pytest.mark.parametrize("use_enum", [True, False])
+@pytest.mark.parametrize("use_bytes", [True, False])
+@pytest.mark.parametrize("value_info", inner_values)
 def test_with_generic_tuple(value_info, use_bytes, use_enum, use_datetime):
     check_one_arg_generic(Tuple, value_info, use_bytes, use_enum, use_datetime)
 
 
-@pytest.mark.parametrize('use_datetime', [True, False])
-@pytest.mark.parametrize('use_enum', [True, False])
-@pytest.mark.parametrize('use_bytes', [True, False])
-@pytest.mark.parametrize('value_info', hashable_inner_values)
+@pytest.mark.parametrize("use_datetime", [True, False])
+@pytest.mark.parametrize("use_enum", [True, False])
+@pytest.mark.parametrize("use_bytes", [True, False])
+@pytest.mark.parametrize("value_info", hashable_inner_values)
 def test_with_generic_set(value_info, use_bytes, use_enum, use_datetime):
     check_one_arg_generic(Set, value_info, use_bytes, use_enum, use_datetime)
 
 
-@pytest.mark.parametrize('use_datetime', [True, False])
-@pytest.mark.parametrize('use_enum', [True, False])
-@pytest.mark.parametrize('use_bytes', [True, False])
-@pytest.mark.parametrize('value_info', hashable_inner_values)
+@pytest.mark.parametrize("use_datetime", [True, False])
+@pytest.mark.parametrize("use_enum", [True, False])
+@pytest.mark.parametrize("use_bytes", [True, False])
+@pytest.mark.parametrize("value_info", hashable_inner_values)
 def test_with_generic_frozenset(value_info, use_bytes, use_enum, use_datetime):
     check_one_arg_generic(
-        FrozenSet, value_info, use_bytes, use_enum, use_datetime)
+        FrozenSet, value_info, use_bytes, use_enum, use_datetime
+    )
 
 
-@pytest.mark.parametrize('use_datetime', [True, False])
-@pytest.mark.parametrize('use_enum', [True, False])
-@pytest.mark.parametrize('use_bytes', [True, False])
-@pytest.mark.parametrize('value_info', hashable_inner_values)
+@pytest.mark.parametrize("use_datetime", [True, False])
+@pytest.mark.parametrize("use_enum", [True, False])
+@pytest.mark.parametrize("use_bytes", [True, False])
+@pytest.mark.parametrize("value_info", hashable_inner_values)
 def test_with_generic_mutable_set(
-        value_info, use_bytes, use_enum, use_datetime):
+    value_info, use_bytes, use_enum, use_datetime
+):
     check_one_arg_generic(
-        MutableSet, value_info, use_bytes, use_enum, use_datetime)
+        MutableSet, value_info, use_bytes, use_enum, use_datetime
+    )
 
 
-@pytest.mark.parametrize('use_datetime', [True, False])
-@pytest.mark.parametrize('use_enum', [True, False])
-@pytest.mark.parametrize('use_bytes', [True, False])
-@pytest.mark.parametrize('value_info', inner_values)
-@pytest.mark.parametrize('key_info', hashable_inner_values)
+@pytest.mark.parametrize("use_datetime", [True, False])
+@pytest.mark.parametrize("use_enum", [True, False])
+@pytest.mark.parametrize("use_bytes", [True, False])
+@pytest.mark.parametrize("value_info", inner_values)
+@pytest.mark.parametrize("key_info", hashable_inner_values)
 def test_with_generic_dict(
-        key_info, value_info, use_bytes, use_enum, use_datetime):
+    key_info, value_info, use_bytes, use_enum, use_datetime
+):
     check_two_args_generic(
-        Dict, key_info, value_info, use_bytes, use_enum, use_datetime)
+        Dict, key_info, value_info, use_bytes, use_enum, use_datetime
+    )
 
 
-@pytest.mark.parametrize('use_datetime', [True, False])
-@pytest.mark.parametrize('use_enum', [True, False])
-@pytest.mark.parametrize('use_bytes', [True, False])
-@pytest.mark.parametrize('value_info', inner_values)
-@pytest.mark.parametrize('key_info', hashable_inner_values)
+@pytest.mark.parametrize("use_datetime", [True, False])
+@pytest.mark.parametrize("use_enum", [True, False])
+@pytest.mark.parametrize("use_bytes", [True, False])
+@pytest.mark.parametrize("value_info", inner_values)
+@pytest.mark.parametrize("key_info", hashable_inner_values)
 def test_with_generic_mapping(
-        key_info, value_info, use_bytes, use_enum, use_datetime):
+    key_info, value_info, use_bytes, use_enum, use_datetime
+):
     check_two_args_generic(
-        Mapping, key_info, value_info, use_bytes, use_enum, use_datetime)
+        Mapping, key_info, value_info, use_bytes, use_enum, use_datetime
+    )
 
 
-@pytest.mark.parametrize('use_datetime', [True, False])
-@pytest.mark.parametrize('use_enum', [True, False])
-@pytest.mark.parametrize('use_bytes', [True, False])
-@pytest.mark.parametrize('value_info', inner_values)
-@pytest.mark.parametrize('key_info', hashable_inner_values)
+@pytest.mark.parametrize("use_datetime", [True, False])
+@pytest.mark.parametrize("use_enum", [True, False])
+@pytest.mark.parametrize("use_bytes", [True, False])
+@pytest.mark.parametrize("value_info", inner_values)
+@pytest.mark.parametrize("key_info", hashable_inner_values)
 def test_with_generic_mutable_mapping(
-        key_info, value_info, use_bytes, use_enum, use_datetime):
+    key_info, value_info, use_bytes, use_enum, use_datetime
+):
     check_two_args_generic(
-        MutableMapping, key_info, value_info, use_bytes, use_enum, use_datetime)
+        MutableMapping, key_info, value_info, use_bytes, use_enum, use_datetime
+    )
 
 
-@pytest.mark.parametrize('use_datetime', [True, False])
-@pytest.mark.parametrize('use_enum', [True, False])
-@pytest.mark.parametrize('use_bytes', [True, False])
-@pytest.mark.parametrize('value_info', inner_values)
-@pytest.mark.parametrize('key_info', hashable_inner_values)
+@pytest.mark.parametrize("use_datetime", [True, False])
+@pytest.mark.parametrize("use_enum", [True, False])
+@pytest.mark.parametrize("use_bytes", [True, False])
+@pytest.mark.parametrize("value_info", inner_values)
+@pytest.mark.parametrize("key_info", hashable_inner_values)
 def test_with_generic_chain_map(
-        key_info, value_info, use_bytes, use_enum, use_datetime):
+    key_info, value_info, use_bytes, use_enum, use_datetime
+):
     check_two_args_generic(
-        ChainMap, key_info, value_info, use_bytes, use_enum, use_datetime)
+        ChainMap, key_info, value_info, use_bytes, use_enum, use_datetime
+    )
 
 
-@pytest.mark.parametrize('x_type', unsupported_field_types)
-@pytest.mark.parametrize('generic_type', generic_sequence_types)
+@pytest.mark.parametrize("x_type", unsupported_field_types)
+@pytest.mark.parametrize("generic_type", generic_sequence_types)
 def test_unsupported_generic_field_types(x_type, generic_type):
     with pytest.raises(UnserializableField):
+
         @dataclass
         class _(DataClassDictMixin):
             # noinspection PyTypeChecker
             x: generic_type[x_type]
 
 
-@pytest.mark.parametrize('x_type', unsupported_typing_primitives)
-@pytest.mark.parametrize('generic_type', generic_sequence_types)
+@pytest.mark.parametrize("x_type", unsupported_typing_primitives)
+@pytest.mark.parametrize("generic_type", generic_sequence_types)
 def test_unsupported_generic_typing_primitives(x_type, generic_type):
     with pytest.raises(UnserializableDataError):
+
         @dataclass
         class _(DataClassDictMixin):
             # noinspection PyTypeChecker
             x: generic_type[x_type]
 
 
-@pytest.mark.parametrize('x_type', unsupported_field_types)
+@pytest.mark.parametrize("x_type", unsupported_field_types)
 def test_unsupported_field_types(x_type):
     with pytest.raises(UnserializableField):
+
         @dataclass
         class _(DataClassDictMixin):
             x: x_type
 
 
-@pytest.mark.parametrize('x_type', unsupported_typing_primitives)
+@pytest.mark.parametrize("x_type", unsupported_typing_primitives)
 def test_unsupported_typing_primitives(x_type):
     with pytest.raises(UnserializableDataError):
+
         @dataclass
         class _(DataClassDictMixin):
             x: x_type
 
 
-@pytest.mark.parametrize('generic_type', generic_mapping_types)
+@pytest.mark.parametrize("generic_type", generic_mapping_types)
 def test_data_class_as_mapping_key(generic_type):
     @dataclass
     class Key(DataClassDictMixin):
         pass
+
     with pytest.raises(UnserializableDataError):
+
         @dataclass
         class _(DataClassDictMixin):
             x: generic_type[Key, int]
@@ -497,34 +535,34 @@ def test_data_class_as_chain_map_key():
     @dataclass
     class Key(DataClassDictMixin):
         pass
+
     with pytest.raises(UnserializableDataError):
+
         @dataclass
         class _(DataClassDictMixin):
             x: ChainMap[Key, int]
 
 
-@pytest.mark.parametrize('use_datetime', [True, False])
-@pytest.mark.parametrize('use_enum', [True, False])
-@pytest.mark.parametrize('use_bytes', [True, False])
-@pytest.mark.parametrize('value_info', inner_values)
+@pytest.mark.parametrize("use_datetime", [True, False])
+@pytest.mark.parametrize("use_enum", [True, False])
+@pytest.mark.parametrize("use_bytes", [True, False])
+@pytest.mark.parametrize("value_info", inner_values)
 def test_with_any(value_info, use_bytes, use_enum, use_datetime):
     @dataclass
     class DataClass(DataClassDictMixin):
         x: Any
 
     x = value_info[1]
-    dumped = {'x': x}
+    dumped = {"x": x}
     instance = DataClass(x)
     instance_dumped = instance.to_dict(
-        use_bytes=use_bytes,
-        use_enum=use_enum,
-        use_datetime=use_datetime
+        use_bytes=use_bytes, use_enum=use_enum, use_datetime=use_datetime
     )
     instance_loaded = DataClass.from_dict(
         dumped,
         use_bytes=use_bytes,
         use_enum=use_enum,
-        use_datetime=use_datetime
+        use_datetime=use_datetime,
     )
     assert instance_dumped == dumped
     assert instance_loaded == instance
@@ -532,10 +570,10 @@ def test_with_any(value_info, use_bytes, use_enum, use_datetime):
     assert same_types(instance_loaded.x, x)
 
 
-@pytest.mark.parametrize('use_datetime', [True, False])
-@pytest.mark.parametrize('use_enum', [True, False])
-@pytest.mark.parametrize('use_bytes', [True, False])
-@pytest.mark.parametrize('value_info', inner_values)
+@pytest.mark.parametrize("use_datetime", [True, False])
+@pytest.mark.parametrize("use_enum", [True, False])
+@pytest.mark.parametrize("use_bytes", [True, False])
+@pytest.mark.parametrize("value_info", inner_values)
 def test_with_optional(value_info, use_bytes, use_enum, use_datetime):
     x_type, x_value, x_value_dumped = value_info
 
@@ -549,38 +587,37 @@ def test_with_optional(value_info, use_bytes, use_enum, use_datetime):
         elif x_value_dumped is Fixture.BYTES:
             v_dumped = Fixture.BYTES if use_bytes else Fixture.BYTES_BASE64
         elif x_value_dumped is Fixture.BYTE_ARRAY:
-            v_dumped = Fixture.BYTE_ARRAY if use_bytes else Fixture.BYTES_BASE64
+            v_dumped = (
+                Fixture.BYTE_ARRAY if use_bytes else Fixture.BYTES_BASE64
+            )
         elif isinstance(x_value_dumped, Enum):
             v_dumped = x_value_dumped if use_enum else x_value_dumped.value
         elif isinstance(x_value_dumped, (datetime, date, time)):
-            v_dumped = x_value_dumped if use_datetime \
-                else x_value_dumped.isoformat()
+            v_dumped = (
+                x_value_dumped if use_datetime else x_value_dumped.isoformat()
+            )
         else:
             v_dumped = x_value_dumped
-        dumped = {'x': v_dumped}
+        dumped = {"x": v_dumped}
         instance_dumped = instance.to_dict(
-            use_bytes=use_bytes,
-            use_enum=use_enum,
-            use_datetime=use_datetime
+            use_bytes=use_bytes, use_enum=use_enum, use_datetime=use_datetime
         )
         instance_loaded = DataClass.from_dict(
             dumped,
             use_bytes=use_bytes,
             use_enum=use_enum,
-            use_datetime=use_datetime
+            use_datetime=use_datetime,
         )
         assert instance_dumped == dumped
         assert instance_loaded == instance
         instance_dumped = instance.to_dict(
-            use_bytes=use_bytes,
-            use_enum=use_enum,
-            use_datetime=use_datetime
+            use_bytes=use_bytes, use_enum=use_enum, use_datetime=use_datetime
         )
         instance_loaded = DataClass.from_dict(
             dumped,
             use_bytes=use_bytes,
             use_enum=use_enum,
-            use_datetime=use_datetime
+            use_datetime=use_datetime,
         )
         assert same_types(instance_dumped, dumped)
         assert same_types(instance_loaded.x, instance.x)
@@ -590,6 +627,7 @@ def test_raises_missing_field():
     @dataclass
     class DataClass(DataClassDictMixin):
         x: int
+
     with pytest.raises(MissingField):
         DataClass.from_dict({})
 
@@ -598,6 +636,7 @@ def test_empty_dataclass():
     @dataclass
     class DataClass(DataClassDictMixin):
         pass
+
     assert DataClass().to_dict() == {}
     assert type(DataClass.from_dict({})) is DataClass
     assert DataClass.from_dict({}).__dict__ == {}
@@ -605,26 +644,29 @@ def test_empty_dataclass():
 
 def test_weird_field_type():
     with pytest.raises(UnserializableDataError):
+
         @dataclass
         class _(DataClassDictMixin):
             x: 123
 
 
-@pytest.mark.parametrize('rounding', [None, decimal.ROUND_UP,
-                                      decimal.ROUND_DOWN])
-@pytest.mark.parametrize('places', [None, 1, 2])
+@pytest.mark.parametrize(
+    "rounding", [None, decimal.ROUND_UP, decimal.ROUND_DOWN]
+)
+@pytest.mark.parametrize("places", [None, 1, 2])
 def test_rounded_decimal(places, rounding):
     @dataclass
     class DataClass(DataClassDictMixin):
         x: RoundedDecimal(places=places, rounding=rounding)
+
     digit = decimal.Decimal(0.35)
     if places is not None:
         exp = decimal.Decimal((0, (1,), -places))
         quantized = digit.quantize(exp, rounding)
     else:
         quantized = digit
-    assert DataClass(digit).to_dict() == {'x': str(quantized)}
-    assert DataClass.from_dict({'x': str(quantized)}) == DataClass(x=quantized)
+    assert DataClass(digit).to_dict() == {"x": str(quantized)}
+    assert DataClass.from_dict({"x": str(quantized)}) == DataClass(x=quantized)
 
 
 def test_serializable_type():
@@ -645,7 +687,6 @@ def test_serialization_strategy():
 
 
 def test_class_vars():
-
     @dataclass
     class DataClass(DataClassDictMixin):
         x: ClassVar[int] = None
@@ -655,7 +696,6 @@ def test_class_vars():
 
 
 def test_init_vars():
-
     @dataclass
     class DataClass(DataClassDictMixin):
         x: InitVar[int] = None
@@ -665,44 +705,40 @@ def test_init_vars():
             if self.y is None and x is not None:
                 self.y = x
 
-    assert DataClass().to_dict() == {'y': None}
-    assert DataClass(x=1).to_dict() == {'y': 1}
+    assert DataClass().to_dict() == {"y": None}
+    assert DataClass(x=1).to_dict() == {"y": 1}
     assert DataClass.from_dict({}) == DataClass()
-    assert DataClass.from_dict({'x': 1}) == DataClass()
+    assert DataClass.from_dict({"x": 1}) == DataClass()
 
 
 def test_dataclass_with_defaults():
-
     @dataclass
     class DataClass(DataClassDictMixin):
         x: int
         y: int = 1
 
-    assert DataClass.from_dict({'x': 0}) == DataClass(x=0, y=1)
+    assert DataClass.from_dict({"x": 0}) == DataClass(x=0, y=1)
 
 
 def test_dataclass_with_field_and_default():
-
     @dataclass
     class DataClass(DataClassDictMixin):
         x: int = field(default=1)
 
     assert DataClass.from_dict({}) == DataClass(x=1)
-    assert DataClass().to_dict() == {'x': 1}
+    assert DataClass().to_dict() == {"x": 1}
 
 
 def test_dataclass_with_field_and_default_factory():
-
     @dataclass
     class DataClass(DataClassDictMixin):
         x: List[str] = field(default_factory=list)
 
     assert DataClass.from_dict({}) == DataClass(x=[])
-    assert DataClass().to_dict() == {'x': []}
+    assert DataClass().to_dict() == {"x": []}
 
 
 def test_derived_dataclass_with_ancestors_defaults():
-
     @dataclass
     class A:
         x: int
@@ -720,13 +756,12 @@ def test_derived_dataclass_with_ancestors_defaults():
     class D(C):
         pass
 
-    assert B.from_dict({'x': 0}) == B(x=0, y=1, z=3)
-    assert C.from_dict({'x': 0}) == C(x=0, y=4, z=3)
-    assert D.from_dict({'x': 0}) == D(x=0, y=4, z=3)
+    assert B.from_dict({"x": 0}) == B(x=0, y=1, z=3)
+    assert C.from_dict({"x": 0}) == C(x=0, y=4, z=3)
+    assert D.from_dict({"x": 0}) == D(x=0, y=4, z=3)
 
 
 def test_derived_dataclass_with_ancestors_and_field_with_default():
-
     @dataclass
     class A:
         x: int = field(default=1)
@@ -749,7 +784,6 @@ def test_derived_dataclass_with_ancestors_and_field_with_default():
 
 
 def test_derived_dataclass_with_ancestors_and_field_with_default_factory():
-
     @dataclass
     class A:
         x: List[int] = field(default_factory=lambda: [1])
@@ -772,40 +806,36 @@ def test_derived_dataclass_with_ancestors_and_field_with_default_factory():
 
 
 def test_invalid_field_value_deserialization():
-
     @dataclass
     class DataClass(DataClassDictMixin):
         x: int
 
     with pytest.raises(InvalidFieldValue):
-        DataClass.from_dict({'x': 'bad_value'})
+        DataClass.from_dict({"x": "bad_value"})
 
 
 def test_invalid_field_value_deserialization_with_default():
-
     @dataclass
     class DataClass(DataClassDictMixin):
         x: int = 1
 
     with pytest.raises(InvalidFieldValue):
-        DataClass.from_dict({'x': 'bad_value'})
+        DataClass.from_dict({"x": "bad_value"})
 
 
 def test_invalid_field_value_deserialization_with_rounded_decimal():
-
     @dataclass
     class DataClass(DataClassDictMixin):
         x: RoundedDecimal()
 
     with pytest.raises(InvalidFieldValue):
-        DataClass.from_dict({'x': 'bad_value'})
+        DataClass.from_dict({"x": "bad_value"})
 
 
 def test_invalid_field_value_deserialization_with_rounded_decimal_with_default():
-
     @dataclass
     class DataClass(DataClassDictMixin):
         x: RoundedDecimal() = Fixture.DECIMAL
 
     with pytest.raises(InvalidFieldValue):
-        DataClass.from_dict({'x': 'bad_value'})
+        DataClass.from_dict({"x": "bad_value"})

--- a/tests/test_datetime_parsers.py
+++ b/tests/test_datetime_parsers.py
@@ -8,6 +8,17 @@ from mashumaro import DataClassDictMixin
 from mashumaro.exceptions import UnserializableField
 
 
+class DateTimeParser:
+    @classmethod
+    def parse(cls, s: str) -> datetime:
+        return datetime.fromisoformat(s)
+
+
+class CallableDateTimeParser:
+    def __call__(self, s):  # pragma no cover
+        pass
+
+
 def test_ciso8601_datetime_parser():
     @dataclass
     class DataClass(DataClassDictMixin):
@@ -78,17 +89,6 @@ def test_global_function_datetime_parser():
     should_be = DataClass(x=datetime(2021, 1, 2, 3, 4, 5))
     instance = DataClass.from_dict({"x": "2021-01-02T03:04:05+03:00"})
     assert instance == should_be
-
-
-class DateTimeParser:
-    @classmethod
-    def parse(cls, s: str) -> datetime:
-        return datetime.fromisoformat(s)
-
-
-class CallableDateTimeParser:
-    def __call__(self, s: str) -> datetime:
-        return datetime.fromisoformat(s)
 
 
 def test_classmethod_datetime_parser():

--- a/tests/test_datetime_parsers.py
+++ b/tests/test_datetime_parsers.py
@@ -86,6 +86,11 @@ class DateTimeParser:
         return datetime.fromisoformat(s)
 
 
+class CallableDateTimeParser:
+    def __call__(self, s: str) -> datetime:
+        return datetime.fromisoformat(s)
+
+
 def test_classmethod_datetime_parser():
     @dataclass
     class DataClass(DataClassDictMixin):
@@ -102,3 +107,12 @@ def test_unsupported_datetime_parser_engine():
         @dataclass
         class DataClass(DataClassDictMixin):
             x: datetime = field(metadata={"deserialize": "unsupported"})
+
+
+def test_callable_class_instance_datetime_parser_engine():
+    instance = CallableDateTimeParser()
+    with pytest.raises(UnserializableField):
+
+        @dataclass
+        class DataClass(DataClassDictMixin):
+            x: datetime = field(metadata={"deserialize": instance})

--- a/tests/test_datetime_parsers.py
+++ b/tests/test_datetime_parsers.py
@@ -6,7 +6,7 @@ from mashumaro import DataClassDictMixin
 def test_ciso8601_datetime_parser():
     @dataclass
     class DataClass(DataClassDictMixin):
-        x: datetime = field(metadata={"engine": "ciso8601"})
+        x: datetime = field(metadata={"deserialize": "ciso8601"})
 
     should_be = DataClass(x=datetime(2021, 1, 2, 3, 4, 5, tzinfo=timezone.utc))
     instance = DataClass.from_dict({"x": "2021-01-02T03:04:05Z"})
@@ -16,7 +16,7 @@ def test_ciso8601_datetime_parser():
 def test_ciso8601_date_parser():
     @dataclass
     class DataClass(DataClassDictMixin):
-        x: date = field(metadata={"engine": "ciso8601"})
+        x: date = field(metadata={"deserialize": "ciso8601"})
 
     should_be = DataClass(x=date(2021, 1, 2))
     instance = DataClass.from_dict({"x": "2021-01-02T03:04:05Z"})
@@ -26,7 +26,7 @@ def test_ciso8601_date_parser():
 def test_ciso8601_time_parser():
     @dataclass
     class DataClass(DataClassDictMixin):
-        x: time = field(metadata={"engine": "ciso8601"})
+        x: time = field(metadata={"deserialize": "ciso8601"})
 
     should_be = DataClass(x=time(3, 4, 5))
     instance = DataClass.from_dict({"x": "2021-01-02T03:04:05Z"})
@@ -36,7 +36,7 @@ def test_ciso8601_time_parser():
 def test_pendulum_datetime_parser():
     @dataclass
     class DataClass(DataClassDictMixin):
-        x: datetime = field(metadata={"engine": "pendulum"})
+        x: datetime = field(metadata={"deserialize": "pendulum"})
 
     should_be = DataClass(x=datetime(2008, 12, 29, 7, tzinfo=timezone.utc))
     instance = DataClass.from_dict({"x": "2009-W01 0700"})
@@ -46,7 +46,7 @@ def test_pendulum_datetime_parser():
 def test_pendulum_date_parser():
     @dataclass
     class DataClass(DataClassDictMixin):
-        x: date = field(metadata={"engine": "pendulum"})
+        x: date = field(metadata={"deserialize": "pendulum"})
 
     should_be = DataClass(x=date(2008, 12, 29))
     instance = DataClass.from_dict({"x": "2009-W01"})
@@ -56,7 +56,7 @@ def test_pendulum_date_parser():
 def test_pendulum_time_parser():
     @dataclass
     class DataClass(DataClassDictMixin):
-        x: time = field(metadata={"engine": "pendulum"})
+        x: time = field(metadata={"deserialize": "pendulum"})
 
     should_be = DataClass(x=time(3, 4, 5))
     instance = DataClass.from_dict({"x": "2009-W01 030405"})

--- a/tests/test_datetime_parsers.py
+++ b/tests/test_datetime_parsers.py
@@ -1,23 +1,63 @@
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timezone, date, time
 from mashumaro import DataClassDictMixin
 
 
-def test_ciso8601_parser():
+def test_ciso8601_datetime_parser():
     @dataclass
     class DataClass(DataClassDictMixin):
         x: datetime = field(metadata={"engine": "ciso8601"})
 
-    assert DataClass.from_dict({"x": "2021-01-02T07:00:00Z"}) == DataClass(
-        x=datetime(2021, 1, 2, 7, tzinfo=timezone.utc)
-    )
+    should_be = DataClass(x=datetime(2021, 1, 2, 3, 4, 5, tzinfo=timezone.utc))
+    instance = DataClass.from_dict({"x": "2021-01-02T03:04:05Z"})
+    assert instance == should_be
 
 
-def test_pendulum_parser():
+def test_ciso8601_date_parser():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: date = field(metadata={"engine": "ciso8601"})
+
+    should_be = DataClass(x=date(2021, 1, 2))
+    instance = DataClass.from_dict({"x": "2021-01-02T03:04:05Z"})
+    assert instance == should_be
+
+
+def test_ciso8601_time_parser():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: time = field(metadata={"engine": "ciso8601"})
+
+    should_be = DataClass(x=time(3, 4, 5))
+    instance = DataClass.from_dict({"x": "2021-01-02T03:04:05Z"})
+    assert instance == should_be
+
+
+def test_pendulum_datetime_parser():
     @dataclass
     class DataClass(DataClassDictMixin):
         x: datetime = field(metadata={"engine": "pendulum"})
 
-    assert DataClass.from_dict({"x": "2009-W01"}) == DataClass(
-        x=datetime(2008, 12, 29, tzinfo=timezone.utc)
-    )
+    should_be = DataClass(x=datetime(2008, 12, 29, 7, tzinfo=timezone.utc))
+    instance = DataClass.from_dict({"x": "2009-W01 0700"})
+    assert instance == should_be
+
+
+def test_pendulum_date_parser():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: date = field(metadata={"engine": "pendulum"})
+
+    should_be = DataClass(x=date(2008, 12, 29))
+    instance = DataClass.from_dict({"x": "2009-W01"})
+    assert instance == should_be
+
+
+def test_pendulum_time_parser():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: time = field(metadata={"engine": "pendulum"})
+
+    should_be = DataClass(x=time(3, 4, 5))
+    instance = DataClass.from_dict({"x": "2009-W01 030405"})
+    assert instance == should_be

--- a/tests/test_datetime_parsers.py
+++ b/tests/test_datetime_parsers.py
@@ -11,3 +11,13 @@ def test_ciso8601_parser():
     assert DataClass.from_dict({"x": "2021-01-02T07:00:00Z"}) == DataClass(
         x=datetime(2021, 1, 2, 7, tzinfo=timezone.utc)
     )
+
+
+def test_pendulum_parser():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: datetime = field(metadata={"engine": "pendulum"})
+
+    assert DataClass.from_dict({"x": "2009-W01"}) == DataClass(
+        x=datetime(2008, 12, 29, tzinfo=timezone.utc)
+    )

--- a/tests/test_datetime_parsers.py
+++ b/tests/test_datetime_parsers.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from mashumaro import DataClassDictMixin
+
+
+def test_ciso8601_parser():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: datetime = field(metadata={"engine": "ciso8601"})
+
+    assert DataClass.from_dict({"x": "2021-01-02T07:00:00Z"}) == DataClass(
+        x=datetime(2021, 1, 2, 7, tzinfo=timezone.utc)
+    )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,86 +1,98 @@
 from typing import List
 
 from mashumaro.exceptions import (
-    MissingField, UnserializableField, InvalidFieldValue
+    InvalidFieldValue,
+    MissingField,
+    UnserializableField,
 )
 
 
 def test_missing_field_simple_field_type_name():
-    exc = MissingField('x', int, object)
-    assert exc.field_type_name == 'builtins.int'
+    exc = MissingField("x", int, object)
+    assert exc.field_type_name == "builtins.int"
 
 
 def test_missing_field_generic_field_type_name():
-    exc = MissingField('x', List[int], object)
-    assert exc.field_type_name == 'typing.List[int]'
+    exc = MissingField("x", List[int], object)
+    assert exc.field_type_name == "typing.List[int]"
 
 
 def test_missing_field_holder_class_name():
-    exc = MissingField('x', int, object)
-    assert exc.holder_class_name == 'builtins.object'
-    exc = MissingField('x', int, List[int])
-    assert exc.holder_class_name == 'typing.List[int]'
+    exc = MissingField("x", int, object)
+    assert exc.holder_class_name == "builtins.object"
+    exc = MissingField("x", int, List[int])
+    assert exc.holder_class_name == "typing.List[int]"
 
 
 def test_missing_field_str():
-    exc = MissingField('x', int, object)
-    assert str(exc) == 'Field "x" of type builtins.int is missing ' \
-                       'in builtins.object instance'
+    exc = MissingField("x", int, object)
+    assert (
+        str(exc) == 'Field "x" of type builtins.int is missing '
+        "in builtins.object instance"
+    )
 
 
 def test_unserializable_field_simple_field_type_name():
-    exc = UnserializableField('x', int, object)
-    assert exc.field_type_name == 'builtins.int'
+    exc = UnserializableField("x", int, object)
+    assert exc.field_type_name == "builtins.int"
 
 
 def test_unserializable_field_generic_field_type_name():
-    exc = UnserializableField('x', List[int], object)
-    assert exc.field_type_name == 'typing.List[int]'
+    exc = UnserializableField("x", List[int], object)
+    assert exc.field_type_name == "typing.List[int]"
 
 
 def test_unserializable_field_holder_class_name():
-    exc = UnserializableField('x', int, object)
-    assert exc.holder_class_name == 'builtins.object'
-    exc = UnserializableField('x', int, List[int])
-    assert exc.holder_class_name == 'typing.List[int]'
+    exc = UnserializableField("x", int, object)
+    assert exc.holder_class_name == "builtins.object"
+    exc = UnserializableField("x", int, List[int])
+    assert exc.holder_class_name == "typing.List[int]"
 
 
 def test_unserializable_field_str():
-    exc = UnserializableField('x', int, object)
-    assert str(exc) == 'Field "x" of type builtins.int in builtins.object ' \
-                       'is not serializable'
+    exc = UnserializableField("x", int, object)
+    assert (
+        str(exc) == 'Field "x" of type builtins.int in builtins.object '
+        "is not serializable"
+    )
 
 
 def test_unserializable_field_with_msg_str():
-    exc = UnserializableField('x', int, object, 'test message')
-    assert str(exc) == 'Field "x" of type builtins.int in builtins.object ' \
-                       'is not serializable: test message'
+    exc = UnserializableField("x", int, object, "test message")
+    assert (
+        str(exc) == 'Field "x" of type builtins.int in builtins.object '
+        "is not serializable: test message"
+    )
 
 
 def test_invalid_field_value_simple_field_type_name():
-    exc = InvalidFieldValue('x', int, 'y', object)
-    assert exc.field_type_name == 'builtins.int'
+    exc = InvalidFieldValue("x", int, "y", object)
+    assert exc.field_type_name == "builtins.int"
 
 
 def test_invalid_field_value_generic_field_type_name():
-    exc = InvalidFieldValue('x', List[int], 'y', object)
-    assert exc.field_type_name == 'typing.List[int]'
+    exc = InvalidFieldValue("x", List[int], "y", object)
+    assert exc.field_type_name == "typing.List[int]"
 
 
 def test_invalid_field_value_holder_class_name():
-    exc = InvalidFieldValue('x', int, 'y', object)
-    assert exc.holder_class_name == 'builtins.object'
-    exc = InvalidFieldValue('x', int, 'y', List[int])
-    assert exc.holder_class_name == 'typing.List[int]'
+    exc = InvalidFieldValue("x", int, "y", object)
+    assert exc.holder_class_name == "builtins.object"
+    exc = InvalidFieldValue("x", int, "y", List[int])
+    assert exc.holder_class_name == "typing.List[int]"
 
 
 def test_invalid_field_value_str():
-    exc = InvalidFieldValue('x', int, 'y', object)
-    assert str(exc) == 'Field "x" of type builtins.int in builtins.object ' \
-                       'has invalid value \'y\''
+    exc = InvalidFieldValue("x", int, "y", object)
+    assert (
+        str(exc) == 'Field "x" of type builtins.int in builtins.object '
+        "has invalid value 'y'"
+    )
 
 
 def test_invalid_field_value_with_msg_str():
-    exc = InvalidFieldValue('x', int, 'y', object, 'test message')
-    assert str(exc) == 'Field "x" of type builtins.int in builtins.object ' \
-                       'has invalid value \'y\': test message'
+    exc = InvalidFieldValue("x", int, "y", object, "test message")
+    assert (
+        str(exc) == 'Field "x" of type builtins.int in builtins.object '
+        "has invalid value 'y': test message"
+    )

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -5,10 +5,10 @@ def test_field_options_helper():
     assert field_options() == {"serialize": None, "deserialize": None}
 
     def serialize(x):
-        return x
+        return x  # pragma no cover
 
     def deserialize(x):
-        return x
+        return x  # pragma no cover
 
     assert (
         field_options(

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,0 +1,19 @@
+from mashumaro import field_options
+
+
+def test_field_options_helper():
+    assert field_options() == {"serialize": None, "deserialize": None}
+
+    def serialize(x):
+        return x
+
+    def deserialize(x):
+        return x
+
+    assert (
+        field_options(
+            serialize=serialize,
+            deserialize=deserialize,
+        )
+        == {"serialize": serialize, "deserialize": deserialize}
+    )

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -14,7 +14,7 @@ def test_bad_pre_deserialize_hook():
             x: int
 
             def __pre_deserialize__(self, d: Dict[Any, Any]) -> Dict[Any, Any]:
-                pass
+                pass  # pragma no cover
 
 
 def test_bad_post_deserialize_hook():
@@ -24,7 +24,7 @@ def test_bad_post_deserialize_hook():
             x: int
 
             def __post_deserialize__(self, obj: "DataClass") -> "DataClass":
-                pass
+                pass  # pragma no cover
 
 
 def test_pre_deserialize_hook():

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -111,17 +111,17 @@ def test_hook_in_parent_class(mocker):
     class A:
         @classmethod
         def __pre_deserialize__(cls, d):
-            return d
+            return d  # pragma no cover
 
         @classmethod
         def __post_deserialize__(cls, obj):
-            return obj
+            return obj  # pragma no cover
 
         def __pre_serialize__(self):
-            return self
+            return self  # pragma no cover
 
         def __post_serialize__(self, d):
-            return d
+            return d  # pragma no cover
 
     @dataclass
     class B(A, DataClassDictMixin):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,80 @@
+from dataclasses import dataclass
+from typing import Any, ClassVar, Dict
+
+import pytest
+
+from mashumaro import DataClassDictMixin
+from mashumaro.exceptions import BadHookSignature
+
+
+def test_bad_pre_deserialize_hook():
+    with pytest.raises(BadHookSignature):
+
+        class DataClass(DataClassDictMixin):
+            x: int
+
+            def __pre_deserialize__(self, d: Dict[Any, Any]) -> Dict[Any, Any]:
+                pass
+
+
+def test_bad_post_deserialize_hook():
+    with pytest.raises(BadHookSignature):
+
+        class DataClass(DataClassDictMixin):
+            x: int
+
+            def __post_deserialize__(self, obj: "DataClass") -> "DataClass":
+                pass
+
+
+def test_pre_deserialize_hook():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: int
+
+        @classmethod
+        def __pre_deserialize__(cls, d: Dict[Any, Any]) -> Dict[Any, Any]:
+            return {k.lower(): v for k, v in d.items()}
+
+    assert DataClass.from_dict({"X": 123}) == DataClass(x=123)
+
+
+def test_post_deserialize_hook():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: int
+
+        @classmethod
+        def __post_deserialize__(cls, obj: "DataClass") -> "DataClass":
+            obj.x = 456
+            return obj
+
+    assert DataClass.from_dict({"x": 123}) == DataClass(x=456)
+
+
+def test_pre_serialize_hook():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: int
+        counter: ClassVar[int] = 0
+
+        def __pre_serialize__(self) -> "DataClass":
+            self.counter += 1
+            return self
+
+    instance = DataClass(x=123)
+    assert instance.to_dict() == {"x": 123}
+    assert instance.counter == 1
+
+
+def test_post_serialize_hook():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: int
+        counter: ClassVar[int] = 0
+
+        def __post_serialize__(self, d: Dict[Any, Any]) -> Dict[Any, Any]:
+            return {k.upper(): v for k, v in d.items()}
+
+    instance = DataClass(x=123)
+    assert instance.to_dict() == {"X": 123}

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -78,3 +78,66 @@ def test_post_serialize_hook():
 
     instance = DataClass(x=123)
     assert instance.to_dict() == {"X": 123}
+
+
+def test_hook_stub_is_not_called(mocker):
+    pre_deserialize_hook = mocker.patch.object(
+        DataClassDictMixin, "__pre_deserialize__"
+    )
+    post_deserialize_hook = mocker.patch.object(
+        DataClassDictMixin, "__post_deserialize__"
+    )
+    pre_serialize_hook = mocker.patch.object(
+        DataClassDictMixin, "__pre_serialize__"
+    )
+    post_serialize_hook = mocker.patch.object(
+        DataClassDictMixin, "__post_serialize__"
+    )
+
+    @dataclass
+    class A(DataClassDictMixin):
+        a: int
+
+    obj = A.from_dict({"a": 1})
+    obj.to_dict()
+
+    pre_deserialize_hook.assert_not_called()
+    post_deserialize_hook.assert_not_called()
+    pre_serialize_hook.assert_not_called()
+    post_serialize_hook.assert_not_called()
+
+
+def test_hook_in_parent_class(mocker):
+    class A:
+        @classmethod
+        def __pre_deserialize__(cls, d):
+            return d
+
+        @classmethod
+        def __post_deserialize__(cls, obj):
+            return obj
+
+        def __pre_serialize__(self):
+            return self
+
+        def __post_serialize__(self, d):
+            return d
+
+    @dataclass
+    class B(A, DataClassDictMixin):
+        a: int
+
+    pre_deserialize_hook = mocker.patch.object(A, "__pre_deserialize__")
+    post_deserialize_hook = mocker.patch.object(A, "__post_deserialize__")
+    pre_serialize_hook = mocker.patch.object(
+        A, "__pre_serialize__", return_value=B(a=1)
+    )
+    post_serialize_hook = mocker.patch.object(A, "__post_serialize__")
+
+    B.from_dict({"a": 1})
+    B(a=1).to_dict()
+
+    pre_deserialize_hook.assert_called_once()
+    post_deserialize_hook.assert_called_once()
+    pre_serialize_hook.assert_called_once()
+    post_serialize_hook.assert_called_once()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,12 +1,13 @@
 import json
-from dataclasses import dataclass
-from typing import List
 from binascii import hexlify
+from dataclasses import dataclass
 from datetime import datetime
+from typing import List
 
 import pytest
 
 from mashumaro import DataClassJSONMixin, MissingField
+
 from .entities import MyEnum
 
 
@@ -15,7 +16,7 @@ def test_to_json():
     class DataClass(DataClassJSONMixin):
         x: List[int]
 
-    dumped = json.dumps({'x': [1, 2, 3]})
+    dumped = json.dumps({"x": [1, 2, 3]})
     assert DataClass([1, 2, 3]).to_json() == dumped
 
 
@@ -24,7 +25,7 @@ def test_from_json():
     class DataClass(DataClassJSONMixin):
         x: List[int]
 
-    dumped = json.dumps({'x': [1, 2, 3]})
+    dumped = json.dumps({"x": [1, 2, 3]})
     assert DataClass.from_json(dumped) == DataClass([1, 2, 3])
 
 
@@ -34,7 +35,7 @@ def test_to_json_with_encoder_params():
         x: List[int]
 
     instance = DataClass(x=[1, 2, 3])
-    dumped = json.dumps({'x': [1, 2, 3]}, indent=2)
+    dumped = json.dumps({"x": [1, 2, 3]}, indent=2)
     assert instance.to_json(indent=2) == dumped
     assert instance.to_json() != dumped
 
@@ -47,11 +48,11 @@ def test_to_json_with_custom_encoder():
 
     def encoder(d):
         dd = dict(d)
-        dd.pop('x_count', None)
+        dd.pop("x_count", None)
         return json.dumps(dd)
 
     instance = DataClass(x=[1, 2, 3], x_count=3)
-    dumped = json.dumps({'x': [1, 2, 3]})
+    dumped = json.dumps({"x": [1, 2, 3]})
     assert instance.to_json(encoder=encoder) == dumped
     assert instance.to_json() != dumped
 
@@ -65,7 +66,7 @@ def test_from_json_with_decoder_params():
         return int(s) * 10
 
     instance = DataClass(x=[10, 20, 30])
-    dumped = json.dumps({'x': [1, 2, 3]})
+    dumped = json.dumps({"x": [1, 2, 3]})
     assert DataClass.from_json(dumped, parse_int=multiple_by_ten) == instance
     assert DataClass.from_json(dumped) != instance
 
@@ -78,17 +79,17 @@ def test_from_json_with_custom_decoder():
 
     def decoder(s):
         d = json.loads(s)
-        d['x_count'] = len(d.get('x', []))
+        d["x_count"] = len(d.get("x", []))
         return d
 
     instance = DataClass(x=[1, 2, 3], x_count=3)
-    dumped = json.dumps({'x': [1, 2, 3]})
+    dumped = json.dumps({"x": [1, 2, 3]})
     assert DataClass.from_json(dumped, decoder=decoder) == instance
     with pytest.raises(MissingField):
         assert DataClass.from_json(dumped)
 
 
-@pytest.mark.parametrize('use_enum', [True, False])
+@pytest.mark.parametrize("use_enum", [True, False])
 def test_json_use_enum(use_enum):
     @dataclass
     class DataClass(DataClassJSONMixin):
@@ -115,26 +116,35 @@ def test_json_use_enum(use_enum):
 
     if not use_enum:
         assert instance.to_json() == dumped_with_enum_normal
-        assert (instance.to_json(dict_params={'use_enum': False}) ==
-                dumped_with_enum_normal)
+        assert (
+            instance.to_json(dict_params={"use_enum": False})
+            == dumped_with_enum_normal
+        )
         assert DataClass.from_json(dumped_with_enum_normal) == instance
-        assert DataClass.from_json(
-            data=dumped_with_enum_normal,
-            dict_params={'use_enum': False}
-        ) == instance
+        assert (
+            DataClass.from_json(
+                data=dumped_with_enum_normal, dict_params={"use_enum": False}
+            )
+            == instance
+        )
     else:
-        assert instance.to_json(
-            default=encode_enum,
-            dict_params={'use_enum': True}
-        ) == dumped_with_enum_upper
-        assert DataClass.from_json(
-            data=dumped_with_enum_upper,
-            object_hook=decode_enum,
-            dict_params={'use_enum': True}
-        ) == instance
+        assert (
+            instance.to_json(
+                default=encode_enum, dict_params={"use_enum": True}
+            )
+            == dumped_with_enum_upper
+        )
+        assert (
+            DataClass.from_json(
+                data=dumped_with_enum_upper,
+                object_hook=decode_enum,
+                dict_params={"use_enum": True},
+            )
+            == instance
+        )
 
 
-@pytest.mark.parametrize('use_bytes', [True, False])
+@pytest.mark.parametrize("use_bytes", [True, False])
 def test_json_use_bytes(use_bytes):
     @dataclass
     class DataClass(DataClassJSONMixin):
@@ -148,37 +158,46 @@ def test_json_use_bytes(use_bytes):
         dd = {}
         for key, value in d.items():
             if value == "313233":
-                value = b'123'
+                value = b"123"
             dd[key] = value
         return dd
 
     dumped_with_bytes_normal = r'{"x": "MTIz\n"}'
     dumped_with_bytes_hex = '{"x": "313233"}'
 
-    instance = DataClass(b'123')
+    instance = DataClass(b"123")
 
     if not use_bytes:
         assert instance.to_json() == dumped_with_bytes_normal
-        assert (instance.to_json(dict_params={'use_bytes': False}) ==
-                dumped_with_bytes_normal)
+        assert (
+            instance.to_json(dict_params={"use_bytes": False})
+            == dumped_with_bytes_normal
+        )
         assert DataClass.from_json(dumped_with_bytes_normal) == instance
-        assert DataClass.from_json(
-            data=dumped_with_bytes_normal,
-            dict_params={'use_bytes': False}
-        ) == instance
+        assert (
+            DataClass.from_json(
+                data=dumped_with_bytes_normal, dict_params={"use_bytes": False}
+            )
+            == instance
+        )
     else:
-        assert instance.to_json(
-            default=encode_bytes,
-            dict_params={'use_bytes': True}
-        ) == dumped_with_bytes_hex
-        assert DataClass.from_json(
-            data=dumped_with_bytes_hex,
-            object_hook=decode_bytes,
-            dict_params={'use_bytes': True}
-        ) == instance
+        assert (
+            instance.to_json(
+                default=encode_bytes, dict_params={"use_bytes": True}
+            )
+            == dumped_with_bytes_hex
+        )
+        assert (
+            DataClass.from_json(
+                data=dumped_with_bytes_hex,
+                object_hook=decode_bytes,
+                dict_params={"use_bytes": True},
+            )
+            == instance
+        )
 
 
-@pytest.mark.parametrize('use_datetime', [True, False])
+@pytest.mark.parametrize("use_datetime", [True, False])
 def test_json_use_datetime(use_datetime):
 
     dt = datetime(2018, 10, 29, 12, 46, 55, 308495)
@@ -199,27 +218,36 @@ def test_json_use_datetime(use_datetime):
             dd[key] = value
         return dd
 
-    dumped_with_dt_normal = json.dumps({'x': dt.isoformat()})
-    dumped_with_dt_timestamp = json.dumps({'x': str(dt.timestamp())})
+    dumped_with_dt_normal = json.dumps({"x": dt.isoformat()})
+    dumped_with_dt_timestamp = json.dumps({"x": str(dt.timestamp())})
 
     instance = DataClass(x=dt)
 
     if not use_datetime:
         assert instance.to_json() == dumped_with_dt_normal
-        assert (instance.to_json(dict_params={'use_datetime': False}) ==
-                dumped_with_dt_normal)
+        assert (
+            instance.to_json(dict_params={"use_datetime": False})
+            == dumped_with_dt_normal
+        )
         assert DataClass.from_json(dumped_with_dt_normal) == instance
-        assert DataClass.from_json(
-            data=dumped_with_dt_normal,
-            dict_params={'use_datetime': False}
-        ) == instance
+        assert (
+            DataClass.from_json(
+                data=dumped_with_dt_normal, dict_params={"use_datetime": False}
+            )
+            == instance
+        )
     else:
-        assert instance.to_json(
-            default=encode_datetime,
-            dict_params={'use_datetime': True}
-        ) == dumped_with_dt_timestamp
-        assert DataClass.from_json(
-            data=dumped_with_dt_timestamp,
-            object_hook=decode_datetime,
-            dict_params={'use_datetime': True}
-        ) == instance
+        assert (
+            instance.to_json(
+                default=encode_datetime, dict_params={"use_datetime": True}
+            )
+            == dumped_with_dt_timestamp
+        )
+        assert (
+            DataClass.from_json(
+                data=dumped_with_dt_timestamp,
+                object_hook=decode_datetime,
+                dict_params={"use_datetime": True},
+            )
+            == instance
+        )

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -5,10 +5,10 @@ import pytest
 
 from mashumaro import DataClassDictMixin
 from mashumaro.meta.helpers import (
+    get_class_that_define_method,
     is_class_var,
     is_generic,
     is_init_var,
-    get_class_that_define_method,
 )
 
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -77,30 +77,3 @@ def test_get_class_that_define_method():
     assert get_class_that_define_method("foo", B) == A
     assert get_class_that_define_method("bar", B) == A
     assert get_class_that_define_method("foobar", B) == B
-
-
-def test_hook_stub_is_not_called(mocker):
-    pre_deserialize_hook = mocker.patch.object(
-        DataClassDictMixin, "__pre_deserialize__"
-    )
-    post_deserialize_hook = mocker.patch.object(
-        DataClassDictMixin, "__post_deserialize__"
-    )
-    pre_serialize_hook = mocker.patch.object(
-        DataClassDictMixin, "__pre_serialize__"
-    )
-    post_serialize_hook = mocker.patch.object(
-        DataClassDictMixin, "__post_serialize__"
-    )
-
-    @dataclass
-    class A(DataClassDictMixin):
-        a: int
-
-    obj = A.from_dict({"a": 1})
-    obj.to_dict()
-
-    pre_deserialize_hook.assert_not_called()
-    post_deserialize_hook.assert_not_called()
-    pre_serialize_hook.assert_not_called()
-    post_serialize_hook.assert_not_called()

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -10,6 +10,7 @@ from mashumaro.meta.helpers import (
     is_generic,
     is_init_var,
 )
+from mashumaro.serializer.base.metaprogramming import CodeBuilder
 
 
 def test_is_generic_unsupported_python():
@@ -77,3 +78,8 @@ def test_get_class_that_define_method():
     assert get_class_that_define_method("foo", B) == A
     assert get_class_that_define_method("bar", B) == A
     assert get_class_that_define_method("foobar", B) == B
+
+
+def test_get_unknown_declared_hook():
+    builder = CodeBuilder(object)
+    assert builder.get_declared_hook("unknown_name") is None

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -62,18 +62,18 @@ def test_no_code_builder():
 def test_get_class_that_define_method():
     class A:
         def foo(self):
-            pass
+            pass  # pragma no cover
 
         @classmethod
         def bar(cls):
-            pass
+            pass  # pragma no cover
 
         def foobar(self):
-            pass
+            pass  # pragma no cover
 
     class B(A):
         def foobar(self):
-            pass
+            pass  # pragma no cover
 
     assert get_class_that_define_method("foo", B) == A
     assert get_class_that_define_method("bar", B) == A

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -4,7 +4,12 @@ from unittest.mock import patch
 import pytest
 
 from mashumaro import DataClassDictMixin
-from mashumaro.meta.helpers import is_class_var, is_generic, is_init_var
+from mashumaro.meta.helpers import (
+    is_class_var,
+    is_generic,
+    is_init_var,
+    get_class_that_define_method,
+)
 
 
 def test_is_generic_unsupported_python():
@@ -51,3 +56,51 @@ def test_no_code_builder():
         assert DataClass.__post_deserialize__(DataClass()) is None
         assert DataClass().__pre_serialize__() is None
         assert DataClass().__post_serialize__({}) is None
+
+
+def test_get_class_that_define_method():
+    class A:
+        def foo(self):
+            pass
+
+        @classmethod
+        def bar(cls):
+            pass
+
+        def foobar(self):
+            pass
+
+    class B(A):
+        def foobar(self):
+            pass
+
+    assert get_class_that_define_method("foo", B) == A
+    assert get_class_that_define_method("bar", B) == A
+    assert get_class_that_define_method("foobar", B) == B
+
+
+def test_hook_stub_is_not_called(mocker):
+    pre_deserialize_hook = mocker.patch.object(
+        DataClassDictMixin, "__pre_deserialize__"
+    )
+    post_deserialize_hook = mocker.patch.object(
+        DataClassDictMixin, "__post_deserialize__"
+    )
+    pre_serialize_hook = mocker.patch.object(
+        DataClassDictMixin, "__pre_serialize__"
+    )
+    post_serialize_hook = mocker.patch.object(
+        DataClassDictMixin, "__post_serialize__"
+    )
+
+    @dataclass
+    class A(DataClassDictMixin):
+        a: int
+
+    obj = A.from_dict({"a": 1})
+    obj.to_dict()
+
+    pre_deserialize_hook.assert_not_called()
+    post_deserialize_hook.assert_not_called()
+    pre_serialize_hook.assert_not_called()
+    post_serialize_hook.assert_not_called()

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,44 +1,49 @@
-from unittest.mock import patch
 from dataclasses import dataclass
+from unittest.mock import patch
 
 import pytest
 
-from mashumaro.meta.helpers import is_generic, is_class_var, is_init_var
 from mashumaro import DataClassDictMixin
+from mashumaro.meta.helpers import is_class_var, is_generic, is_init_var
 
 
 def test_is_generic_unsupported_python():
-    with patch('mashumaro.meta.helpers.PY_36', False):
-        with patch('mashumaro.meta.helpers.PY_37', False):
-            with patch('mashumaro.meta.helpers.PY_38', False):
-                with patch('mashumaro.meta.helpers.PY_39', False):
+    with patch("mashumaro.meta.helpers.PY_36", False):
+        with patch("mashumaro.meta.helpers.PY_37", False):
+            with patch("mashumaro.meta.helpers.PY_38", False):
+                with patch("mashumaro.meta.helpers.PY_39", False):
                     with pytest.raises(NotImplementedError):
                         is_generic(int)
 
 
 def test_is_class_var_unsupported_python():
-    with patch('mashumaro.meta.helpers.PY_36', False):
-        with patch('mashumaro.meta.helpers.PY_37', False):
-            with patch('mashumaro.meta.helpers.PY_38', False):
-                with patch('mashumaro.meta.helpers.PY_39', False):
+    with patch("mashumaro.meta.helpers.PY_36", False):
+        with patch("mashumaro.meta.helpers.PY_37", False):
+            with patch("mashumaro.meta.helpers.PY_38", False):
+                with patch("mashumaro.meta.helpers.PY_39", False):
                     with pytest.raises(NotImplementedError):
                         is_class_var(int)
 
 
 def test_is_init_var_unsupported_python():
-    with patch('mashumaro.meta.helpers.PY_36', False):
-        with patch('mashumaro.meta.helpers.PY_37', False):
-            with patch('mashumaro.meta.helpers.PY_38', False):
-                with patch('mashumaro.meta.helpers.PY_39', False):
+    with patch("mashumaro.meta.helpers.PY_36", False):
+        with patch("mashumaro.meta.helpers.PY_37", False):
+            with patch("mashumaro.meta.helpers.PY_38", False):
+                with patch("mashumaro.meta.helpers.PY_39", False):
                     with pytest.raises(NotImplementedError):
                         is_init_var(int)
 
 
 def test_no_code_builder():
-    with patch('mashumaro.serializer.base.dict.'
-               'DataClassDictMixin.__init_subclass__', lambda: ...):
+    with patch(
+        "mashumaro.serializer.base.dict."
+        "DataClassDictMixin.__init_subclass__",
+        lambda: ...,
+    ):
+
         @dataclass
         class DataClass(DataClassDictMixin):
             pass
+
         assert DataClass.from_dict({}) is None
         assert DataClass().to_dict() is None

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -47,3 +47,7 @@ def test_no_code_builder():
 
         assert DataClass.from_dict({}) is None
         assert DataClass().to_dict() is None
+        assert DataClass.__pre_deserialize__({}) is None
+        assert DataClass.__post_deserialize__(DataClass()) is None
+        assert DataClass().__pre_serialize__() is None
+        assert DataClass().__post_serialize__({}) is None

--- a/tests/test_metadata_options.py
+++ b/tests/test_metadata_options.py
@@ -198,3 +198,15 @@ def test_path_like_overridden():
     should_be = DataClass(x=Path("/ABC"))
     instance = DataClass.from_dict({"x": "/abc"})
     assert instance == should_be
+
+
+def test_serialize_option():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: datetime = field(
+            metadata={"serialize": lambda v: v.strftime("%Y-%m-%d %H:%M:%S")}
+        )
+
+    should_be = {"x": "2021-01-02 03:04:05"}
+    instance = DataClass(x=datetime(2021, 1, 2, 3, 4, 5, tzinfo=timezone.utc))
+    assert instance.to_dict() == should_be

--- a/tests/test_metadata_options.py
+++ b/tests/test_metadata_options.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timezone
+from pathlib import Path
 
 import ciso8601
 import pytest
@@ -172,4 +173,28 @@ def test_derived_dataclass_metadata_deserialize_option():
     instance = B.from_dict(
         {"x": "2021-01-02T03:04:05Z", "y": "2021-01-02T03:04:05Z"}
     )
+    assert instance == should_be
+
+
+def test_bytearray_overridden():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: bytearray = field(
+            metadata={"deserialize": lambda s: s.upper().encode()}
+        )
+
+    should_be = DataClass(x=bytearray(b"ABC"))
+    instance = DataClass.from_dict({"x": "abc"})
+    assert instance == should_be
+
+
+def test_path_like_overridden():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: Path = field(
+            metadata={"deserialize": lambda s: Path(str(s).upper())}
+        )
+
+    should_be = DataClass(x=Path("/ABC"))
+    instance = DataClass.from_dict({"x": "/abc"})
     assert instance == should_be

--- a/tests/test_metadata_options.py
+++ b/tests/test_metadata_options.py
@@ -200,7 +200,7 @@ def test_path_like_overridden():
     assert instance == should_be
 
 
-def test_serialize_option():
+def test_datetime_serialize_option():
     @dataclass
     class DataClass(DataClassDictMixin):
         x: datetime = field(

--- a/tests/test_metadata_options.py
+++ b/tests/test_metadata_options.py
@@ -109,10 +109,17 @@ def test_unsupported_datetime_parser_engine():
             x: datetime = field(metadata={"deserialize": "unsupported"})
 
 
-def test_callable_class_instance_datetime_parser_engine():
+def test_callable_class_instance_datetime_parser():
     instance = CallableDateTimeParser()
     with pytest.raises(UnserializableField):
 
         @dataclass
         class DataClass(DataClassDictMixin):
             x: datetime = field(metadata={"deserialize": instance})
+
+
+def test_lambda_datetime_parser():
+    with pytest.raises(UnserializableField):
+        @dataclass
+        class DataClass(DataClassDictMixin):
+            x: datetime = field(metadata={"deserialize": lambda x: x})

--- a/tests/test_metadata_options.py
+++ b/tests/test_metadata_options.py
@@ -210,3 +210,22 @@ def test_datetime_serialize_option():
     should_be = {"x": "2021-01-02 03:04:05"}
     instance = DataClass(x=datetime(2021, 1, 2, 3, 4, 5, tzinfo=timezone.utc))
     assert instance.to_dict() == should_be
+
+def test_non_serializable_class_options():
+    @dataclass
+    class DataClassA:
+        name: str
+        unique_id: int
+
+    @dataclass
+    class DataClassB(DataClassDictMixin):
+        objA: DataClassA = field(
+            metadata={"serialize": lambda v: 'None', "deserialize": lambda v: 'None'}
+        )
+        name: str
+    instance = DataClassB(name="testing", objA={"name": "testingA", "unique_id" :123})
+    assert instance
+    should_be = {"name": "testing", "objA": 'None'}
+    assert instance.to_dict() == should_be
+
+

--- a/tests/test_msgpack.py
+++ b/tests/test_msgpack.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
-from typing import List
 from datetime import datetime
+from typing import List
 
 import msgpack
 
@@ -11,7 +11,8 @@ def test_to_msgpack():
     @dataclass
     class DataClass(DataClassMessagePackMixin):
         x: List[int]
-    dumped = msgpack.packb({'x': [1, 2, 3]})
+
+    dumped = msgpack.packb({"x": [1, 2, 3]})
     assert DataClass([1, 2, 3]).to_msgpack() == dumped
 
 
@@ -19,7 +20,8 @@ def test_from_msgpack():
     @dataclass
     class DataClass(DataClassMessagePackMixin):
         x: List[int]
-    dumped = msgpack.packb({'x': [1, 2, 3]})
+
+    dumped = msgpack.packb({"x": [1, 2, 3]})
     assert DataClass.from_msgpack(dumped) == DataClass([1, 2, 3])
 
 
@@ -27,6 +29,7 @@ def test_to_msg_pack_datetime():
     @dataclass
     class DataClass(DataClassMessagePackMixin):
         x: datetime
+
     dt = datetime(2018, 10, 29, 12, 46, 55, 308495)
-    dumped = msgpack.packb({'x': dt.isoformat()})
+    dumped = msgpack.packb({"x": dt.isoformat()})
     assert DataClass(dt).to_msgpack() == dumped

--- a/tests/test_timezones.py
+++ b/tests/test_timezones.py
@@ -1,69 +1,69 @@
 from dataclasses import dataclass
-from datetime import timezone, timedelta
-
-from mashumaro import DataClassDictMixin
+from datetime import timedelta, timezone
 
 import pytest
 
+from mashumaro import DataClassDictMixin
 
 time_zones = [
-    (timezone(timedelta(hours=-12)), 'UTC-12:00'),              # Baker Island
-    (timezone(timedelta(hours=-11)), 'UTC-11:00'),              # American Samoa
-    (timezone(timedelta(hours=-10)), 'UTC-10:00'),              # Hawaii
-    (timezone(timedelta(hours=-9, minutes=-30)), 'UTC-09:30'),  # Marquesas Isl.
-    (timezone(timedelta(hours=-9)), 'UTC-09:00'),               # Gambier Isl.
-    (timezone(timedelta(hours=-8)), 'UTC-08:00'),               # Pitcairn Isl.
-    (timezone(timedelta(hours=-7)), 'UTC-07:00'),               # Sonora
-    (timezone(timedelta(hours=-6)), 'UTC-06:00'),               # Costa Rica
-    (timezone(timedelta(hours=-5)), 'UTC-05:00'),               # Colombia
-    (timezone(timedelta(hours=-4)), 'UTC-04:00'),               # Bolivia
-    (timezone(timedelta(hours=-3, minutes=-30)), 'UTC-03:30'),  # Canada
-    (timezone(timedelta(hours=-3)), 'UTC-03:00'),               # Argentina
-    (timezone(timedelta(hours=-2)), 'UTC-02:00'),               # South Georgia
-    (timezone(timedelta(hours=-1)), 'UTC-01:00'),               # Cape Verde
-    (timezone(timedelta(hours=0)), 'UTC'),                      # Burkina Faso
-    (timezone(timedelta(hours=1)), 'UTC+01:00'),                # Algeria
-    (timezone(timedelta(hours=2)), 'UTC+02:00'),                # Botswana
-    (timezone(timedelta(hours=3)), 'UTC+03:00'),                # Moscow
-    (timezone(timedelta(hours=3, minutes=30)), 'UTC+03:30'),    # Iran
-    (timezone(timedelta(hours=4)), 'UTC+04:00'),                # Armenia
-    (timezone(timedelta(hours=4, minutes=30)), 'UTC+04:30'),    # Afghanistan
-    (timezone(timedelta(hours=5)), 'UTC+05:00'),                # Maldives
-    (timezone(timedelta(hours=5, minutes=30)), 'UTC+05:30'),    # India
-    (timezone(timedelta(hours=5, minutes=45)), 'UTC+05:45'),    # Nepal
-    (timezone(timedelta(hours=6)), 'UTC+06:00'),                # Bangladesh
-    (timezone(timedelta(hours=6, minutes=30)), 'UTC+06:30'),    # Myanmar
-    (timezone(timedelta(hours=7)), 'UTC+07:00'),                # Cambodia
-    (timezone(timedelta(hours=8)), 'UTC+08:00'),                # Hong Kong
-    (timezone(timedelta(hours=8, minutes=45)), 'UTC+08:45'),    # Eucla
-    (timezone(timedelta(hours=9)), 'UTC+09:00'),                # Japan
-    (timezone(timedelta(hours=9, minutes=30)), 'UTC+09:30'),    # N. Australia
-    (timezone(timedelta(hours=10)), 'UTC+10:00'),               # Queensland
-    (timezone(timedelta(hours=10, minutes=30)), 'UTC+10:30'),   # Australia
-    (timezone(timedelta(hours=11)), 'UTC+11:00'),               # Vanuatu
-    (timezone(timedelta(hours=12)), 'UTC+12:00'),               # Nauru
-    (timezone(timedelta(hours=12, minutes=45)), 'UTC+12:45'),   # New Zealand
-    (timezone(timedelta(hours=13)), 'UTC+13:00'),               # Tonga
-    (timezone(timedelta(hours=14)), 'UTC+14:00'),               # Kiribati
+    (timezone(timedelta(hours=-12)), "UTC-12:00"),  # Baker Island
+    (timezone(timedelta(hours=-11)), "UTC-11:00"),  # American Samoa
+    (timezone(timedelta(hours=-10)), "UTC-10:00"),  # Hawaii
+    (
+        timezone(timedelta(hours=-9, minutes=-30)),
+        "UTC-09:30",
+    ),  # Marquesas Isl.
+    (timezone(timedelta(hours=-9)), "UTC-09:00"),  # Gambier Isl.
+    (timezone(timedelta(hours=-8)), "UTC-08:00"),  # Pitcairn Isl.
+    (timezone(timedelta(hours=-7)), "UTC-07:00"),  # Sonora
+    (timezone(timedelta(hours=-6)), "UTC-06:00"),  # Costa Rica
+    (timezone(timedelta(hours=-5)), "UTC-05:00"),  # Colombia
+    (timezone(timedelta(hours=-4)), "UTC-04:00"),  # Bolivia
+    (timezone(timedelta(hours=-3, minutes=-30)), "UTC-03:30"),  # Canada
+    (timezone(timedelta(hours=-3)), "UTC-03:00"),  # Argentina
+    (timezone(timedelta(hours=-2)), "UTC-02:00"),  # South Georgia
+    (timezone(timedelta(hours=-1)), "UTC-01:00"),  # Cape Verde
+    (timezone(timedelta(hours=0)), "UTC"),  # Burkina Faso
+    (timezone(timedelta(hours=1)), "UTC+01:00"),  # Algeria
+    (timezone(timedelta(hours=2)), "UTC+02:00"),  # Botswana
+    (timezone(timedelta(hours=3)), "UTC+03:00"),  # Moscow
+    (timezone(timedelta(hours=3, minutes=30)), "UTC+03:30"),  # Iran
+    (timezone(timedelta(hours=4)), "UTC+04:00"),  # Armenia
+    (timezone(timedelta(hours=4, minutes=30)), "UTC+04:30"),  # Afghanistan
+    (timezone(timedelta(hours=5)), "UTC+05:00"),  # Maldives
+    (timezone(timedelta(hours=5, minutes=30)), "UTC+05:30"),  # India
+    (timezone(timedelta(hours=5, minutes=45)), "UTC+05:45"),  # Nepal
+    (timezone(timedelta(hours=6)), "UTC+06:00"),  # Bangladesh
+    (timezone(timedelta(hours=6, minutes=30)), "UTC+06:30"),  # Myanmar
+    (timezone(timedelta(hours=7)), "UTC+07:00"),  # Cambodia
+    (timezone(timedelta(hours=8)), "UTC+08:00"),  # Hong Kong
+    (timezone(timedelta(hours=8, minutes=45)), "UTC+08:45"),  # Eucla
+    (timezone(timedelta(hours=9)), "UTC+09:00"),  # Japan
+    (timezone(timedelta(hours=9, minutes=30)), "UTC+09:30"),  # N. Australia
+    (timezone(timedelta(hours=10)), "UTC+10:00"),  # Queensland
+    (timezone(timedelta(hours=10, minutes=30)), "UTC+10:30"),  # Australia
+    (timezone(timedelta(hours=11)), "UTC+11:00"),  # Vanuatu
+    (timezone(timedelta(hours=12)), "UTC+12:00"),  # Nauru
+    (timezone(timedelta(hours=12, minutes=45)), "UTC+12:45"),  # New Zealand
+    (timezone(timedelta(hours=13)), "UTC+13:00"),  # Tonga
+    (timezone(timedelta(hours=14)), "UTC+14:00"),  # Kiribati
 ]
 
 
-@pytest.mark.parametrize(['tz', 'tz_string'], time_zones)
+@pytest.mark.parametrize(["tz", "tz_string"], time_zones)
 def test_timezones(tz, tz_string):
-
     @dataclass
     class DataClass(DataClassDictMixin):
         x: timezone
 
-    assert DataClass(tz).to_dict() == {'x': tz_string}
-    assert DataClass.from_dict({'x': tz_string}) == DataClass(tz)
+    assert DataClass(tz).to_dict() == {"x": tz_string}
+    assert DataClass.from_dict({"x": tz_string}) == DataClass(tz)
 
 
 def test_invalid_timezone():
-
     @dataclass
     class DataClass(DataClassDictMixin):
         x: timezone
 
     with pytest.raises(ValueError):
-        DataClass.from_dict({'x': 'UTC+03:00:01'})
+        DataClass.from_dict({"x": "UTC+03:00:01"})

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -10,7 +10,8 @@ def test_to_yaml():
     @dataclass
     class DataClass(DataClassYAMLMixin):
         x: List[int]
-    dumped = yaml.dump({'x': [1, 2, 3]})
+
+    dumped = yaml.dump({"x": [1, 2, 3]})
     assert DataClass([1, 2, 3]).to_yaml() == dumped
 
 
@@ -18,5 +19,6 @@ def test_from_yaml():
     @dataclass
     class DataClass(DataClassYAMLMixin):
         x: List[int]
-    dumped = yaml.dump({'x': [1, 2, 3]})
+
+    dumped = yaml.dump({"x": [1, 2, 3]})
     assert DataClass.from_yaml(dumped) == DataClass([1, 2, 3])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,11 +1,4 @@
-from typing import (
-    List,
-    Deque,
-    Tuple,
-    Set,
-    ChainMap,
-    Mapping,
-)
+from typing import ChainMap, Deque, List, Mapping, Set, Tuple
 
 
 def same_types(first, second):
@@ -14,12 +7,14 @@ def same_types(first, second):
     elif isinstance(first, ChainMap):
         return all(map(lambda x: same_types(*x), zip(first.maps, second.maps)))
     elif isinstance(first, Mapping):
-        return (all(map(lambda x: same_types(*x),
-                        zip(first.keys(), second.keys()))) and
-                all(map(lambda x: same_types(*x),
-                        zip(first.values(), second.values()))))
+        return all(
+            map(lambda x: same_types(*x), zip(first.keys(), second.keys()))
+        ) and all(
+            map(lambda x: same_types(*x), zip(first.values(), second.values()))
+        )
     elif isinstance(first, Set):
-        return all(map(lambda x: same_types(*x),
-                       zip(sorted(first), sorted(second))))
+        return all(
+            map(lambda x: same_types(*x), zip(sorted(first), sorted(second)))
+        )
     else:
         return type(first) is type(second)


### PR DESCRIPTION
The metadata options for 'serialize' and 'deserialize' don't work for classes which are not serializable.  Also in order to fix this I had to put back __name__ instead of __qualname__. 